### PR TITLE
HERITAGE-55 Update styles for search results filters

### DIFF
--- a/sass/etna.scss
+++ b/sass/etna.scss
@@ -59,6 +59,9 @@
 @use "@nationalarchives/frontend/nationalarchives/tools/typography";
 @use "@nationalarchives/frontend/nationalarchives/variables/grid";
 
+// Redeclare $orange to match OHOS orange
+$orange: #FA8334;
+
 .tna-heading--l,
 .tna-heading--m {
     @include colourTools.colour-font("font-base");

--- a/sass/includes/search/_search-button.scss
+++ b/sass/includes/search/_search-button.scss
@@ -1,27 +1,25 @@
 .search-button {
-    background-color: $color__grey-700 !important;
+    cursor: pointer;
     text-decoration: none;
-    color: $color__white !important;
-    border: $default__border;
+    border: 2px solid;
     padding: 0.5em 0.9em;
     display: inline-block;
     min-width: 24px;
     text-align: center;
+    font-weight: bold;
+    border-color: $color__off-black;
 
+    &,
     &:visited,
     &:active {
-        background-color: $color__grey-700 !important;
-        color: $color__white !important;
+        background-color: $orange !important;
+        color: $color__off-black !important;
     }
 
     &:hover {
-        background-color: $color__white !important;
-        color: $color__grey-700 !important;
+        background-color: $color__off-black !important;
+        color: $color__white !important;
         text-decoration: none;
-    }
-
-    &:focus {
-        // @include focus-default;
     }
 
     &--primary {
@@ -42,20 +40,17 @@
     }
 
     &--secondary {
-        border-color: $color__grey-light !important;
-        background-color: $color__grey-light !important;
-        color: $color__black;
-
+        &,
         &:visited,
         &:active {
-            background-color: $color__grey-light !important;
-            color: $color__black !important;
+            background-color: $color__off-black !important;
+            color: $color__white !important;
         }
 
         &:hover {
-            border-color: $color__black !important;
-            background-color: $color__black !important;
-            color: $color__white;
+            border-color: currentColor !important;
+            background-color: $color__grey-200 !important;
+            color: $color__off-black;
             text-decoration: none;
         }
     }

--- a/sass/includes/search/_search-filters.scss
+++ b/sass/includes/search/_search-filters.scss
@@ -1,15 +1,21 @@
 .search-filters {
-    background-color: $color__grey-200;
-    border: 1px solid $color__grey-500;
+    background-color: $color__grey-300;
     padding: 1rem;
 
+    &__header {
+        display: flex;
+        gap: 1rem;
+        align-items: center;
+        margin-bottom: 1rem;
+    }
+
     &__heading {
-        font-size: 1.3em;
+        color: inherit;
     }
 
     &__widget-list {
         list-style: none;
-        padding-left: 0.5rem;
+        padding-left: 0;
 
         &:focus {
             outline: 5px solid $color__focus-outline-light-bg;
@@ -18,6 +24,34 @@
 
     &__widget-list-item {
         input {
+            // These styles only apply to the search page items for the moment
+            // If it's identified that this style needs to be used elsewhere
+            // in future, consider moving the code in to a more reusable state
+            &[type=checkbox] {
+                flex: none;
+                margin-right: 0.5rem;
+                appearance: none;
+                width: 1.875rem;
+                height: 1.875rem;
+                border: 2px solid $color__off-black;
+                background-color: $color__grey-200;
+                display: grid;
+                place-content: center;
+
+                &:checked {
+                    background-color: $orange;
+
+                    &::before {
+                        content: "";
+                        clip-path: polygon(85.41% 0, 39.58985% 69.04%, 12.5% 38.1026666667%, 0 52.3883888889%, 41.66015% 100%, 100% 14.2857222222%);
+                        width: 20px;
+                        height: 18px;
+                        display: block;
+                        background-color: $color__off-black;
+                    }
+                }
+            }
+
             &:focus {
                 outline: 5px solid $color__focus-outline-light-bg;
             }
@@ -25,7 +59,7 @@
 
         label {
             cursor: pointer;
-            display: inline-block;
+            display: flex;
             margin-bottom: 0.5rem;
             max-width: 100%;
         }
@@ -38,7 +72,11 @@
     &__submit {
         @extend .search-button;
         display: block;
-        margin-top: 0.5rem;
+        margin-left: auto;
+
+        &:not(&__heading) {
+            margin-top: 0.5rem;
+        }
     }
 
     &__label,
@@ -57,27 +95,28 @@
         &--block {
             display: block;
             max-width: 100%;
+            color: inherit;
+            font-weight: 600;
         }
     }
 
     &__search {
         margin-bottom: 0.5rem;
-        border: 1px solid $color__grey-500;
-        border-radius: 0.5rem;
+        border: 2px solid currentColor;
+        /* border-radius: 0.5rem; */
         width: 100%;
         height: 3rem;
         padding: 1rem;
     }
 
-    &__accordion-section {
-        background-color: $color__grey-100;
-        padding: 0.5rem;
+    &__section {
+        padding-bottom: 1rem;
         margin-bottom: 1rem;
-        border: 1px solid $color__grey-400;
+        border-bottom: 1px solid $color__off-black;
 
         &-heading {
-            font-size: 1rem;
-            font-weight: normal;
+            font-weight: 600;
+            color: inherit;
         }
 
         &-link {
@@ -128,6 +167,10 @@
     display: inline-block;
     margin-right: 20px;
     margin-bottom: 0;
+
+    input {
+        border: 2px solid currentColor;
+    }
 }
 
 .tna-form-group .tna-form-group:last-of-type {
@@ -146,10 +189,11 @@
 .tna-input--width-2 {
     max-width: 2.75em;
 }
+
 .tna-input--width-4 {
     max-width: 4em;
 }
 
 .example-text {
-    color: $color__grey-600;
+    font-size: 1rem;
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,6 +1,6 @@
 {% load static wagtailuserbar wagtailcore_tags wagtailsettings_tags  wagtailmetadata_tags robots_meta %}<!DOCTYPE html>
 {% get_settings %}
-<html class="tna-template tna-template--light-theme tna-template--yellow-accent no-js {% block html_class%}{% endblock %}" lang="en-GB">
+<html class="tna-template tna-template--light-theme no-js {% block html_class%}{% endblock %}" lang="en-GB">
     <head>
     {% if request.in_preview_panel %}
     <base target="_blank">

--- a/templates/search/blocks/search_filters.html
+++ b/templates/search/blocks/search_filters.html
@@ -17,9 +17,15 @@
 
 <div class="search-filters" data-search-filters>
     {% comment %} Hidden on archive & creator as they currently have no filters  {% endcomment %}
-    <h2 class="tna-heading-l search-filters__heading">Refine results</h2>
+
 
     <form method="GET" data-id="filters-form"  id="catalogue-filters-form">
+
+        <div class="search-filters__header">
+            <h2 class="tna-heading-l search-filters__heading">Filters</h2>
+            <input type="submit" value="Update" class="search-filters__submit">
+        </div>
+
         {% comment %}
          {% if form.group.value == 'tna' %}
             <div class="search-filters__form-block">
@@ -33,10 +39,10 @@
 
         {% if form.filter_keyword %}
             <div class="search-filters__form-block">
-                <label for="{{form.filter_keyword.id_for_label}}" class="search-filters__label--block">Search within results:</label>
+                <label for="{{form.filter_keyword.id_for_label}}" class="tna-heading-s search-filters__label--block">Search within results</label>
                 {{ form.filter_keyword }}
                 {{ form.filter_keyword.errors }}
-                <input type="submit" value="Search" class="search-filters__submit">
+                <input type="submit" value="Search" class="search-button search-button--secondary">
             </div>
         {% endif %}
 
@@ -44,10 +50,10 @@
             <h3 class="tna-heading-m sr-only">Edit filters</h3>
 
             {% if form.group.value == 'tna' or form.group.value == 'digitised' or form.group.value == 'nonTna' %}
-                <div class="search-filters__accordion-section">
+                <div class="search-filters__section">
                     <fieldset role="group" aria-describedby="from-date">
                         <legend>
-                            <h4 class="tna-heading-s search-filters__accordion-section-heading" id="record_covering_date">Dates</h4>
+                            <h4 class="tna-heading-s search-filters__section-heading" id="record_covering_date">Dates</h4>
                         </legend>
 
                         <span class="example-text" id="from-date">For example, 27 3 2007 or 2007</span>
@@ -82,7 +88,6 @@
 
                         </div>
 
-                        <input type="submit" value="Update" class="search-filters__submit">
                     </fieldset>
                 </div>
             {% endif %}
@@ -107,10 +112,10 @@
 
 
             {% if form.group.value == 'tna' or form.group.value == 'digitised' %}
-                <div class="search-filters__accordion-section">
+                <div class="search-filters__section">
                     <fieldset role="group" aria-describedby="opening-start-date">
                         <legend>
-                            <h4 class="tna-heading-s search-filters__accordion-section-heading" id="record_opening_date">Record opening date</h4>
+                            <h4 class="tna-heading-s search-filters__section-heading" id="record_opening_date">Record opening date</h4>
                         </legend>
 
                         <div class="search-filters__opening-date-section">
@@ -128,7 +133,6 @@
                             {{ form.opening_start_date }}
 
                         </div>
-                        
 
                         <div class="search-filters__opening-date-section">
 
@@ -145,7 +149,6 @@
 
                         </div>
 
-                        <input type="submit" value="Update" class="search-filters__submit">
                     </fieldset>
                 </div>
 
@@ -168,6 +171,8 @@
 
         {# render hidden inputs for fields controlled by other forms #}
         {% render_fields_as_hidden form include='q group sort_by sort_order' %}
+
+        <input type="submit" value="Update" class="search-filters__submit">
 
     </form>
 

--- a/templates/search/includes/filter.html
+++ b/templates/search/includes/filter.html
@@ -1,7 +1,7 @@
 {% if field.field.choices and field.field.choices_updated %}
-    <div class="search-filters__accordion-section">
+    <div class="search-filters__section">
         <fieldset>
-            <legend><h4 class="tna-heading-s search-filters__accordion-section-heading">{{ field.label }}</h4></legend>
+            <legend><h4 class="tna-heading-s search-filters__section-heading">{{ field.label }}</h4></legend>
             <div>
                 {{ field.errors }}
                 {{ field }}
@@ -11,7 +11,6 @@
                     <a href="{% url 'search-catalogue-long-filter-chooser' field_name=field.name %}?{{ request.GET.urlencode }}"  aria-label='See more'>See more</a>
                 {% endif %}
             {% endif %}
-            <input type="submit" value="Update" class="search-filters__submit">
         </fieldset>
     </div>
 {% else %}


### PR DESCRIPTION
Ticket URL: [HERITAGE-55](https://national-archives.atlassian.net/browse/HERITAGE-55)

## About these changes

Update styling for search results filters. Adds new style for checkbox, introduces updated `$orange` colour variable to override the `!default` and updates general look and feel to match design.

## How to check these changes

Visit `/search/catalogue/` and observe changes to filters on the left of the page

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [x] Ensured that PR includes only commits relevant to the ticket
- [ ] Waited for all CI jobs to pass before requesting a review
- [ ] Added/updated tests and documentation where relevant

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
