### PR TITLE
HERITAGE-58 Add mark up and styles for named entity tags on search re…

### DIFF
--- a/sass/etna.scss
+++ b/sass/etna.scss
@@ -280,6 +280,7 @@ These are Etna specific components, created using BEM and following our guidelin
 
 @import "ohos/header";
 @import "ohos/footer";
+@import "ohos/tags";
 
 /* Un-comment when front-end toolkit is fixed
 

--- a/sass/includes/search/_search-results.scss
+++ b/sass/includes/search/_search-results.scss
@@ -166,6 +166,16 @@
             display: block;
         }
     }
+
+    &__tags-list {
+        margin-top: 1em;
+        margin-bottom: 1em;
+        list-style: none;
+        display: flex;
+        flex-wrap: wrap;
+        padding: 0;
+        gap: 0.75rem;
+    }
 }
 
 .filter-indicator {

--- a/sass/ohos/_tags.scss
+++ b/sass/ohos/_tags.scss
@@ -1,0 +1,49 @@
+.ohos-tag {
+    display: flex;
+    border: 1px solid;
+    border-radius: 5px;
+    overflow: hidden;
+    font-size: 16px;
+    max-width: 260px;
+
+    &--location {
+        background-color: #fd3f03;
+    }
+
+    &--person {
+        background-color: #84a59d;
+    }
+
+    &--organisation {
+        background-color: #b5e2fa;
+    }
+
+    &--misc {
+        background-color: #fe1d57;
+    }
+
+    &--other {
+        background-color: #faf0ca;
+    }
+
+    &__inner {
+        display: block;
+        padding: 0.25rem 0.5rem;
+    }
+
+    &__link {
+        display: flex;
+        gap: 0.25rem;
+        color: inherit;
+        align-items: center;
+        padding: 0.25rem 0.5rem;
+        background-color: $color__grey-200;
+        border-left: 1px solid;
+
+        &:hover {
+            text-decoration-thickness: inherit;
+            background-color: $color__off-black;
+            color: $color__grey-200;
+        }
+    }
+}

--- a/templates/includes/tags.html
+++ b/templates/includes/tags.html
@@ -1,0 +1,37 @@
+{% comment %}
+    Tags are part of the search results cards. We don't have the data to display for the
+    cards yet, but mark up and styles have been created ahead of integration. These will
+    be shown conditionally when digital community content is displayed
+{% endcomment %}
+
+<ul class="search-results__tags-list">
+    <li>
+        <span class="ohos-tag ohos-tag--location badge badge-pill">
+            <span class="ohos-tag__inner">Location</span>
+        </span>
+    </li>
+
+    <li>
+        <span class="ohos-tag ohos-tag--person">
+            <span class="ohos-tag__inner">Person</span>
+        </span>
+    </li>
+
+    <li>
+        <span class="ohos-tag ohos-tag--organisation">
+            <span class="ohos-tag__inner">Organisation</span>
+        </span>
+    </li>
+
+    <li>
+        <span class="ohos-tag ohos-tag--misc">
+            <span class="ohos-tag__inner">Miscellaneous</span>
+        </span>
+    </li>
+
+    <li>
+        <span class="ohos-tag ohos-tag--other">
+            <span class="ohos-tag__inner">Other</span>
+        </span>
+    </li>
+</ul>

--- a/templates/search/blocks/search_results__list-card--grid.html
+++ b/templates/search/blocks/search_results__list-card--grid.html
@@ -94,6 +94,8 @@
             {% comment %}End debug attributes.{% endcomment %}
         </dl>
 
+        {% include 'includes/tags.html' %}
+
 
     {% if record.is_digitised %}
         {% if record.closure_status not in closure_closed_status %}

--- a/templates/search/blocks/search_results__list-card.html
+++ b/templates/search/blocks/search_results__list-card.html
@@ -62,6 +62,7 @@
 
         </dl>
 
+        {% include 'includes/tags.html' %}
     </div>
 
     {% if record.is_digitised or apply_teaser_image %}


### PR DESCRIPTION
Ticket URL: [HERITAGE-58](https://national-archives.atlassian.net/browse/HERITAGE-58)

## About these changes

Hard coded named entity tags for search results cards. As we don't have the data yet, the acceptance criteria of the ticket is to create the mark up and colours for the tags 

## How to check these changes

On a search results page, view the results card in both list and grid view to see the tags in place

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [x] Ensured that PR includes only commits relevant to the ticket
- [ ] Waited for all CI jobs to pass before requesting a review
- [ ] Added/updated tests and documentation where relevant

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)


[HERITAGE-58]: https://national-archives.atlassian.net/browse/HERITAGE-58?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ