### PR TITLE
HERITAGE-65 Add related tags to details page

### DIFF
--- a/sass/includes/_record-details.scss
+++ b/sass/includes/_record-details.scss
@@ -17,4 +17,30 @@
             font-weight: bold;
         }
     }
+
+    &__related-tags {
+        margin: 1rem 0 5rem;
+        border: 1px solid $color__grey-500;
+        padding: 1.5rem;
+
+        &-list {
+            dt {
+                margin-top: 1.5rem;
+                margin-bottom: 1rem;
+
+                &:first-child {
+                    margin-top: 0;
+                }
+            }
+
+            dd {
+                margin-bottom: 1rem;
+                margin-left: 0;
+
+                &:last-child {
+                    margin-bottom: 0;
+                }
+            }
+        }
+    }
 }

--- a/sass/includes/search/_search-results__list-card.scss
+++ b/sass/includes/search/_search-results__list-card.scss
@@ -266,21 +266,26 @@
     }
 }
 
-dt {
-    float: left;
-    clear: left;
-    width: 140px;
-    font-weight: 400;
-    color: rgba(52, 51, 56);
-    padding-right: 0.3em;
-}
+// Temp fix to stop global styles leaking into record details related tags
+// This code will be removed when updating to the latest tna-frontend from ETNA
+// @link https://github.com/nationalarchives/ds-wagtail/pull/1466/files
+.search-results {
+    dt {
+        float: left;
+        clear: left;
+        width: 140px;
+        font-weight: 400;
+        color: rgba(52, 51, 56);
+        padding-right: 0.3em;
+    }
 
-dd {
-    margin: 0 0 0 45px;
-    padding: 0 0 0.5em 1em;
-    font-weight: 400;
-    color: rgba(52, 51, 56);
-    overflow: hidden;
+    dd {
+        margin: 0 0 0 45px;
+        padding: 0 0 0.5em 1em;
+        font-weight: 400;
+        color: rgba(52, 51, 56);
+        overflow: hidden;
+    }
 }
 
 /*---additional styles for All results--*/

--- a/sass/ohos/_tags.scss
+++ b/sass/ohos/_tags.scss
@@ -1,10 +1,9 @@
 .ohos-tag {
-    display: flex;
+    display: inline-flex;
     border: 1px solid;
     border-radius: 5px;
     overflow: hidden;
     font-size: 16px;
-    max-width: 260px;
 
     &--location {
         background-color: #fd3f03;
@@ -34,11 +33,16 @@
     &__link {
         display: flex;
         gap: 0.25rem;
-        color: inherit;
         align-items: center;
         padding: 0.25rem 0.5rem;
         background-color: $color__grey-200;
-        border-left: 1px solid;
+        border-left: 1px solid $color__off-black;
+
+        &,
+        &:link,
+        &:visited {
+            color: inherit;
+        }
 
         &:hover {
             text-decoration-thickness: inherit;

--- a/templates/includes/related-tags.html
+++ b/templates/includes/related-tags.html
@@ -47,9 +47,9 @@
         <dt>Miscellaneous:</dt>
         <dd>
             <span class="ohos-tag ohos-tag--misc">
-                <span class="ohos-tag__inner">Location</span>
+                <span class="ohos-tag__inner">Miscellaneous</span>
 
-                <a href="https://test-deploy-ohos-xjy4lfq-rasrzs7pi6sd4.uk-1.platformsh.site/search/catalogue/?filter_keyword=&covering_date_from_0=&covering_date_from_1=&covering_date_from_2=&covering_date_to_0=&covering_date_to_1=&covering_date_to_2=&collection=ADM&opening_start_date_0=&opening_start_date_1=&opening_start_date_2=&opening_end_date_0=&opening_end_date_1=&opening_end_date_2=&q=&sort_by=&sort_order=asc&group=tna" class="ohos-tag__link">
+                <a href="https://test-deploy-ohos-xjy4lfq-rasrzs7pi6sd4.uk-1.platformsh.site/search/catalogue/?filter_keyword=&covering_date_from_0=&covering_date_from_1=&covering_date_from_2=&covering_date_to_0=&covering_date_to_1=&covering_date_to_2=&collection=ADM&opening_start_date_0=&opening_start_date_1=&opening_start_date_2=&opening_end_date_0=&opening_end_date_1=&opening_end_date_2=&q=&sort_by=&sort_order=asc&group=tna" class="ohos-tag__link" title="See other (tag name) results in the collection">
                     Collection
                 </a>
             </span>
@@ -60,7 +60,7 @@
             <span class="ohos-tag ohos-tag--other">
                 <span class="ohos-tag__inner">Other</span>
 
-                <a href="https://test-deploy-ohos-xjy4lfq-rasrzs7pi6sd4.uk-1.platformsh.site/search/catalogue/?filter_keyword=&covering_date_from_0=&covering_date_from_1=&covering_date_from_2=&covering_date_to_0=&covering_date_to_1=&covering_date_to_2=&collection=ADM&opening_start_date_0=&opening_start_date_1=&opening_start_date_2=&opening_end_date_0=&opening_end_date_1=&opening_end_date_2=&q=&sort_by=&sort_order=asc&group=tna" class="ohos-tag__link">
+                <a href="https://test-deploy-ohos-xjy4lfq-rasrzs7pi6sd4.uk-1.platformsh.site/search/catalogue/?filter_keyword=&covering_date_from_0=&covering_date_from_1=&covering_date_from_2=&covering_date_to_0=&covering_date_to_1=&covering_date_to_2=&collection=ADM&opening_start_date_0=&opening_start_date_1=&opening_start_date_2=&opening_end_date_0=&opening_end_date_1=&opening_end_date_2=&q=&sort_by=&sort_order=asc&group=tna" class="ohos-tag__link" title="See other (tag name) results in the collection">
                     Collection
                 </a>
             </span>

--- a/templates/includes/related-tags.html
+++ b/templates/includes/related-tags.html
@@ -1,0 +1,69 @@
+{% comment %}
+    Related tags are part of the record details page. We don't have the data to display for the
+    tags yet, but mark up and styles have been created ahead of integration. These will
+    be shown conditionally when digital community content is displayed
+{% endcomment %}
+
+<div class="record-details__related-tags">
+    <h3>Related tags</h3>
+
+    <dl class="record-details__related-tags-list">
+        <dt>Location:</dt>
+        <dd>
+            <span class="ohos-tag ohos-tag--location">
+                <span class="ohos-tag__inner">Location</span>
+
+                <a href="https://www.wikidata.org/wiki/Q208209" target="_blank" class="ohos-tag__link">
+                    Wikidata
+                    <i aria-hidden="true" class="ohos-tag__link-icon fa-solid fa-external-link"></i>
+                </a>
+            </span>
+        </dd>
+
+        <dt>Person:</dt>
+        <dd>
+            <span class="ohos-tag ohos-tag--person">
+                <span class="ohos-tag__inner">Person</span>
+
+                <a href="https://www.wikidata.org/wiki/Q208209" target="_blank" class="ohos-tag__link">
+                    Wikidata
+                    <i aria-hidden="true" class="ohos-tag__link-icon fa-solid fa-external-link"></i>
+                </a>
+            </span>
+        </dd>
+
+        <dt>Organisation:</dt>
+        <dd>
+            <span class="ohos-tag ohos-tag--organisation">
+                <span class="ohos-tag__inner">Organisation</span>
+
+                <a href="https://www.wikidata.org/wiki/Q208209" target="_blank" class="ohos-tag__link">
+                    Wikidata
+                    <i aria-hidden="true" class="ohos-tag__link-icon fa-solid fa-external-link"></i>
+                </a>
+            </span>
+        </dd>
+
+        <dt>Miscellaneous:</dt>
+        <dd>
+            <span class="ohos-tag ohos-tag--misc">
+                <span class="ohos-tag__inner">Location</span>
+
+                <a href="https://test-deploy-ohos-xjy4lfq-rasrzs7pi6sd4.uk-1.platformsh.site/search/catalogue/?filter_keyword=&covering_date_from_0=&covering_date_from_1=&covering_date_from_2=&covering_date_to_0=&covering_date_to_1=&covering_date_to_2=&collection=ADM&opening_start_date_0=&opening_start_date_1=&opening_start_date_2=&opening_end_date_0=&opening_end_date_1=&opening_end_date_2=&q=&sort_by=&sort_order=asc&group=tna" class="ohos-tag__link">
+                    Collection
+                </a>
+            </span>
+        </dd>
+
+        <dt>Other:</dt>
+        <dd>
+            <span class="ohos-tag ohos-tag--other">
+                <span class="ohos-tag__inner">Other</span>
+
+                <a href="https://test-deploy-ohos-xjy4lfq-rasrzs7pi6sd4.uk-1.platformsh.site/search/catalogue/?filter_keyword=&covering_date_from_0=&covering_date_from_1=&covering_date_from_2=&covering_date_to_0=&covering_date_to_1=&covering_date_to_2=&collection=ADM&opening_start_date_0=&opening_start_date_1=&opening_start_date_2=&opening_end_date_0=&opening_end_date_1=&opening_end_date_2=&q=&sort_by=&sort_order=asc&group=tna" class="ohos-tag__link">
+                    Collection
+                </a>
+            </span>
+        </dd>
+    </dl>
+</div>

--- a/templates/includes/tags.html
+++ b/templates/includes/tags.html
@@ -6,7 +6,7 @@
 
 <ul class="search-results__tags-list">
     <li>
-        <span class="ohos-tag ohos-tag--location badge badge-pill">
+        <span class="ohos-tag ohos-tag--location">
             <span class="ohos-tag__inner">Location</span>
         </span>
     </li>

--- a/templates/records/record_detail.html
+++ b/templates/records/record_detail.html
@@ -13,13 +13,28 @@
     {% include "includes/records/record-cta-panel.html" %}
 
     <div class="container">
-
         {% include "includes/records/record-title.html" %}
         {% include "includes/records/hierarchy-global.html" %}
 
         <h2 id="record-details-heading" class="tna-heading-l">Description and record details</h2>
 
+        {# If there are no related tags to display #}
         {% include "includes/records/record-details.html" %}
+    </div>
+
+    {# If there are related tags to display #}
+    <div class="tna-container">
+        <div class="tna-column tna-column--width-2-3 tna-column--width-2-3-medium tna-column--full-small tna-column--full-tiny">
+            {% include "includes/records/record-details.html" %}
+        </div>
+
+        <div class="tna-column tna-column--width-1-3 tna-column--width-1-3-medium tna-column--full-small tna-column--full-tiny">
+            {% include "includes/related-tags.html" %}
+        </div>
+    </div>
+
+    <div class="container">
+
         {% include "includes/records/record-crosslink-panel.html" %}
 
         {% if record.hierarchy %}


### PR DESCRIPTION
Ticket URL: [HERITAGE-65](https://national-archives.atlassian.net/browse/HERITAGE-65)

## About these changes

Add related tags section to details page

## How to check these changes

Visit details page from search results. Eg - `/catalogue/id/C8077549/` and observe tags in right hand column

The table is currently duplicated to show how the mark up should be set with or without the tags as we don't yet have the logic / data for this

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [x] Ensured that PR includes only commits relevant to the ticket
- [x] Waited for all CI jobs to pass before requesting a review
- [ ] Added/updated tests and documentation where relevant

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)


[HERITAGE-65]: https://national-archives.atlassian.net/browse/HERITAGE-65?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ