### PR TITLE
HERITAGE-76 Remove hierarchy block and order/download box from detail…

### DIFF
--- a/templates/records/record_detail.html
+++ b/templates/records/record_detail.html
@@ -14,7 +14,6 @@
 
     <div class="container">
         {% include "includes/records/record-title.html" %}
-        {% include "includes/records/hierarchy-global.html" %}
 
         <h2 id="record-details-heading" class="tna-heading-l">Description and record details</h2>
 
@@ -34,9 +33,6 @@
     </div>
 
     <div class="container">
-
-        {% include "includes/records/record-crosslink-panel.html" %}
-
         {% if record.hierarchy %}
             {% if record.hierarchy|length > 2 %}
                 <h2 class="tna-heading-l">This record is in the series</h2>
@@ -44,7 +40,6 @@
                 {% include "includes/records/record-series-panel.html" %}
             {% endif %}
         {% endif %}
-
     </div>
 
 {% endblock %}


### PR DESCRIPTION
Ticket URL: [HERITAGE-76](https://national-archives.atlassian.net/browse/HERITAGE-76)

## About these changes

Amend details page to remove hierarchy block and order/download box

## How to check these changes

Visit detail page - eg `/catalogue/id/C8077549/` and observe that the hierarchy block above the details table and the download box below are no longer present.

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [x] Ensured that PR includes only commits relevant to the ticket
- [x] Waited for all CI jobs to pass before requesting a review
- [ ] Added/updated tests and documentation where relevant

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)


[HERITAGE-76]: https://national-archives.atlassian.net/browse/HERITAGE-76?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ