### PR TITLE
FIX: CSS changes to fix updates from Etna

### DIFF
--- a/sass/includes/search/_search-filters.scss
+++ b/sass/includes/search/_search-filters.scss
@@ -93,7 +93,11 @@
     &__submit {
         @extend .search-button;
         display: block;
-        margin-top: 1.2em;
+        margin-left: auto;
+
+        &:not(&__heading) {
+            margin-top: 0.5rem;
+        }
     }
 
     &__label,

--- a/sass/includes/search/_search-filters.scss
+++ b/sass/includes/search/_search-filters.scss
@@ -90,6 +90,12 @@
         margin-bottom: 1rem;
     }
 
+    &__label,
+    &__checkbox,
+    &__submit {
+        cursor: pointer;
+    }
+
     &__submit {
         @extend .search-button;
         display: block;
@@ -98,12 +104,6 @@
         &:not(&__heading) {
             margin-top: 0.5rem;
         }
-    }
-
-    &__label,
-    &__checkbox,
-    &__submit {
-        cursor: pointer;
     }
 
     &__label {

--- a/sass/includes/search/_search-hero.scss
+++ b/sass/includes/search/_search-hero.scss
@@ -33,8 +33,6 @@
     }
 
     &__form {
-        display: flex;
-
         &-submit {
             @extend .search-button;
             cursor: pointer;

--- a/sass/includes/search/_search-results__list-card.scss
+++ b/sass/includes/search/_search-results__list-card.scss
@@ -249,23 +249,6 @@
     }
 }
 
-dt {
-    float: left;
-    clear: left;
-    width: 140px;
-    font-weight: 400;
-    color: rgb(52 51 56);
-    padding-right: 0.3em;
-}
-
-dd {
-    margin: 0 0 0 45px;
-    padding: 0 0 0.5em 1em;
-    font-weight: 400;
-    color: rgb(52 51 56);
-    overflow: hidden;
-}
-
 /* ---additional styles for All results-- */
 
 .featured-search__website-results__head {

--- a/templates/search/blocks/search_results__list-card--grid.html
+++ b/templates/search/blocks/search_results__list-card--grid.html
@@ -35,58 +35,60 @@
         <p class="search-results__list-card-description">
             {{ record.listing_description }}
         </p>
-        <dl class="search-results__list-card-metadata">
+        <dl class="tna-dl tna-dl--plain tna-dl--icon-padding tna-!--margin-bottom-s">
             {% if record.held_by %}
-                <dt class="search-results__list-card-metadata-item search-results__list-card-metadata-item-held-by-icon">
-                    Held by:
+                <dt>
+                    <i class="fa-solid fa-landmark"></i>
+                    Held by
                 </dt>
                 <dd>{{ record.held_by }}</dd>
             {% endif %}
 
             {% if record.date_created %}
-                <dt class="search-results__list-card-metadata-item search-results__list-card-metadata-item-date-icon">
-                    Date:
+                <dt>
+                    <i class="fa-solid fa-calendar"></i>
+                    Date
                 </dt>
-                <dd> {{ record.date_created }}</dd>
+                <dd>
+                    <date>{{ record.date_created }}</date>
+                </dd>
             {% endif %}
 
             {% if record.reference_number %}
-            <dt class="search-results__list-card-metadata-item search-results__list-card-metadata-item-data-icon">
-
+            <dt>
+                <i class="fa-solid fa-database"></i>
                 {% if form.group.value == 'archive' %}
-                Archon code:
+                Archon code
                 {% else %}
-                Reference:
+                Reference
                 {% endif %}
-
-
             </dt>
             <dd>{{ record.reference_number }}</dd>
             {% endif %}
 
             <!--
             {% if record.record_opening %}
-                <dt class="search-results__list-card-metadata-item search-results__list-card-metadata-item-subjects-icon">
+                <dt>
                     Record opening date:
                 </dt>
                 <dd>{{ record.record_opening }}</dd>
             {% endif %}
             -->
             {% if form.group.value == bucketkeys.CREATOR.value and record.type %}
-                <dt class="search-results__list-card-metadata-item">
-                    Type:
+                <dt>
+                    Type
                 </dt>
                 <dd>{{ record.type }}</dd>
             {% endif %}
 
             {% comment %}Debug attributes. Output to allow k-int to adjust the ES index{% endcomment %}
             <!--
-            <dt class="search-results__list-card-metadata-item">
+            <dt>
                 IAID:
             </dt>
 
             <dd>{{ record.iaid }}</dd>>
-            <dt class="search-results__list-card-metadata-item">
+            <dt>
                 Score:
             </dt>
             <dd;>{{ record.score }}</dd>

--- a/templates/search/blocks/search_results__list-card.html
+++ b/templates/search/blocks/search_results__list-card.html
@@ -25,38 +25,43 @@
             {{ record.listing_description }}
         </p>
 
-        <dl class="search-results__list-card-metadata">
+        <dl class="tna-dl tna-dl--plain tna-dl--icon-padding tna-!--margin-bottom-s">
             {% if record.held_by %}
-            <dt class="search-results__list-card-metadata-item-held-by-icon">Held by:</dt>
+            <dt>
+                <i class="fa-solid fa-landmark"></i>
+                Held by
+            </dt>
             <dd>{{ record.held_by }}</dd>
             {% endif %}
 
 
 
             {% if record.date_created %}
-            <dt class="search-results__list-card-metadata-item search-results__list-card-metadata-item-date-icon">
-                Date:</dt>
+            <dt>
+                <i class="fa-solid fa-calendar"></i>
+                Date
+            </dt>
             <dd>
                 <date>{{ record.date_created }}</date></dd>
             {% endif %}
 
             {% if record.reference_number %}
-            <dt class="search-results__list-card-metadata-item search-results__list-card-metadata-item-data-icon">
+            <dt>
+                <i class="fa-solid fa-database"></i>
                 {% if form.group.value == 'archive' %}
-                Archon code:
+                Archon code
                 {% else %}
-                Reference:
+                Reference
                 {% endif %}
             </dt>
-            <dd>{{ record.reference_number }}
+            <dd>
+                {{ record.reference_number }}
             </dd>
             {% endif %}
 
             {% if form.group.value == bucketkeys.CREATOR.value and record.type %}
-            <dt class="search-results__list-card-metadata-item">
-                Type:</dt>
-            <dd>{{ record.type }}
-            </dd>
+            <dt>Type</dt>
+            <dd>{{ record.type }}</dd>
             {% endif %}
 
 


### PR DESCRIPTION
## About these changes

Fix related tags and header search box where regressions had been introduced from updated being pulled from Etna

## How to check these changes

Check homepage `/` - Header search box
Search page `/search/catalogue/` - Results cards and search header
Details page `/catalogue/id/C8077549/` - Related tags

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer
- [ ] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [x] Ensured that PR includes only commits relevant to the ticket
- [x] Waited for all CI jobs to pass before requesting a review
- [ ] Added/updated tests and documentation where relevant

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
