### PR TITLE
HERITAGE-53 Update jumbo tabs in search to match OHOS design

### DIFF
--- a/sass/etna.scss
+++ b/sass/etna.scss
@@ -10,7 +10,7 @@
         "page-background": #f4f4f4,
         "background-tint": #d9d9d6,
         "font-base": #222,
-        "font-dark": #047584,
+        "font-dark": #067584,
         "font-light": rgb(0 0 0 / 0.7),
         "icon-light": rgb(0 0 0 / 0.45),
         "link": #1d70ab,
@@ -58,6 +58,10 @@
 @use "@nationalarchives/frontend/nationalarchives/tools/spacing";
 @use "@nationalarchives/frontend/nationalarchives/tools/typography";
 @use "@nationalarchives/frontend/nationalarchives/variables/grid";
+
+// Redeclare $orange to match OHOS orange
+$orange: #fa8334;
+$body-bg: var(--page-background);
 
 /*
 
@@ -206,9 +210,6 @@ Modified to match the existing site (for now)
 */
 
 @import "https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,300..800;1,300..800&family=Roboto:ital,wght@0,400;0,500;0,700;1,400;1,500;1,700&family=Roboto+Mono&display=swap";
-
-// Redeclare $orange to match OHOS orange
-$orange: #fa8334;
 
 .tna-heading--l,
 .tna-heading--m {

--- a/sass/includes/search/_search-buckets.scss
+++ b/sass/includes/search/_search-buckets.scss
@@ -4,8 +4,11 @@
     @media only screen and (max-width: $screen__md) {
         display: none;
     }
+
     display: flex;
     flex-wrap: wrap;
+    background-color: $color__grey-300;
+    margin-bottom: 2rem;
 
     &__list {
         display: flex;
@@ -14,24 +17,24 @@
         margin-left: auto;
         margin-right: auto;
         margin-bottom: 0;
-        padding-left: 1.5rem;
-        padding-right: 1.5rem;
         order: -1;
 
         &-item {
             display: inline-block;
             list-style: none;
-            width: 18%;
+            flex: 1;
             margin-right: 0.5rem;
             margin-left: 0.5rem;
             min-height: 100px;
-            margin-bottom: 1rem;
             font-family: $font__supria-sans;
             font-size: 1.2rem;
 
-            &--website {
-                @extend .search-buckets__list-item;
-                width: 15%;
+            &:first-child {
+                margin-left: 0;
+            }
+
+            &:last-child {
+                margin-right: 0;
             }
 
             @media only screen and (max-width: $screen__md) {
@@ -50,7 +53,7 @@
     &__link {
         text-align: center;
         padding: 14px;
-        border: 1px solid $color__grey-500;
+        padding-top: 9px;
         // @include colour.colour-border("keyline", 1px);
         width: 100%;
         margin-top: auto;
@@ -61,6 +64,7 @@
         display: flex;
         align-items: center;
         justify-content: center;
+        border-top: 5px solid transparent;
 
         &,
         &:link,
@@ -71,8 +75,8 @@
         &[aria-current="true"],
         &:hover,
         &:focus {
-            background-color: $color__yellow;
-            color: #000;
+            background: $body-bg;
+            border-top-color: var(--font-dark);
         }
     }
 

--- a/sass/includes/search/_search-hero.scss
+++ b/sass/includes/search/_search-hero.scss
@@ -5,16 +5,6 @@
     background-color: $color__grey-300;
     padding-top: 2rem;
     padding-bottom: 2rem;
-    margin-bottom: 2rem;
-
-    &--has-nav {
-        padding: 2rem;
-        padding-bottom: 0;
-
-        @media only screen and (max-width: $screen__md) {
-            padding: 1rem;
-        }
-    }
 
     &__container {
         margin-left: auto;

--- a/sass/includes/search/_search-sort-view.scss
+++ b/sass/includes/search/_search-sort-view.scss
@@ -134,7 +134,10 @@
 }
 
 .search-others {
-    margin-bottom: 1rem;
+    margin: 0;
+    padding-bottom: 1rem;
+    background-color: $color__grey-300;
+
     @media only screen and (min-width: #{$screen__md + 1px}) {
         display: none;
     }

--- a/templates/home/home_page.html
+++ b/templates/home/home_page.html
@@ -8,25 +8,23 @@
 
 {% block content %}
 
-    <form action="/search/catalogue" method="GET" id="analytics-search-landing-hero">
-        <div class="search-hero">
-            <div class="tna-container">
-                <div class="tna-column tna-column--full">
-                    <div class="search-hero__container">
-                        <h1 class="tna-heading-xl search-hero__heading">Find community-generated history</h1>
-                        <div class="search-hero__form">
-                            <label for="id_q" class="search-hero__label">
-                                <span class="sr-only">Enter search term.</span> Search by keyword, person or community.
-                            </label>
-                            {{ form.q.errors }}
-                            {{ form.q }}
-                            <input type="submit" value="Search" class="search-hero__form-submit">
-                        </div>
-                    </div>
+    <div class="search-hero">
+        <div class="tna-container">
+            <div class="tna-column tna-column--full">
+                <div class="search-hero__container">
+                    <h1 class="tna-heading-xl search-hero__heading">Find community-generated history</h1>
+                    <form action="/search/catalogue" method="GET" class="search-hero__form" id="analytics-search-landing-hero">
+                        <label for="id_q" class="search-hero__label">
+                            <span class="sr-only">Enter search term.</span> Search by keyword, person or community.
+                        </label>
+                        {{ form.q.errors }}
+                        {{ form.q }}
+                        <input type="submit" value="Search" class="search-hero__form-submit">
+                    </form>
                 </div>
             </div>
         </div>
-    </form>
+    </div>
 
     <div class="tna-section">
         <div class="tna-container">

--- a/templates/search/blocks/catalogue_search_buckets.html
+++ b/templates/search/blocks/catalogue_search_buckets.html
@@ -1,41 +1,44 @@
-
 <!--new form element-->
 <div class="search-sort-view search-others">
+    <div class="tna-container">
+        <div class="tna-column tna-column--full">
+            <form method="GET" class="search-sort-view__form" data-id="search-bucket-mobile" id="search-bucket-mobile">
+                <h2 class="tna-heading-l search-sort-view__heading">
+                    <label for="id-for-this-dropdown">Show results from:</label>
+                </h2>
+                <select name="group" id="id-for-this-dropdown" class="search-sort-view__form-select">
+                    {% for bucket in buckets %}
+                        {% if bucket.result_count != None %}
+                            <option value="{{ bucket.key }}" {% if bucket.is_current %}selected{% endif %} >{{ bucket.label_with_count }}</option>
+                        {%endif%}
+                    {% endfor %}
+                </select>
 
-   <form method="GET" class="search-sort-view__form" data-id="search-bucket-mobile" id="search-bucket-mobile">
-   
-    
-        <h2 class="tna-heading-l search-sort-view__heading">
-            <label for="id-for-this-dropdown">Show results from:</label>
-        </h2>
-        <select name="group" id="id-for-this-dropdown" class="search-sort-view__form-select">
-            {% for bucket in buckets %}
-                {% if bucket.result_count != None %}
-                    <option value="{{ bucket.key }}" {% if bucket.is_current %}selected{% endif %} >{{ bucket.label_with_count }}</option>
-                {%endif%}
-            {% endfor %}        
-        </select>
+                <input type="submit" value="Update" class="search-sort-view__form-submit">
 
-        <input type="submit" value="Update" class="search-sort-view__form-submit">
-
-        {% if form.q.value %}
-            {{form.q.as_hidden}}
-        {% endif %}
-
-    </form>
+                {% if form.q.value %}
+                    {{form.q.as_hidden}}
+                {% endif %}
+            </form>
+        </div>
+    </div>
 </div>
 <!-- end new form element-->
 
 <nav class="search-buckets" aria-label="Record categories">
-    <ul class="search-buckets__list" data-id="search-buckets-list">
-        {% for bucket in buckets %}
-            {% if bucket.result_count != None %}
-                <li class="search-buckets__list-item" data-current="{% if bucket.is_current %}true{% else %}false{% endif %}">
-                    <a href="?{% if form.q.value %}q={{ form.q.value }}&{% endif %}group={{ bucket.key }}" class="search-buckets__link" aria-current="{% if bucket.is_current %}true{% else %}false{% endif %}">
-                        {{ bucket.label_with_count }}
-                    </a>
-                </li>
-            {%endif%}
-        {% endfor %}
-    </ul>
+    <div class="tna-container">
+        <div class="tna-column tna-column--full">
+            <ul class="search-buckets__list" data-id="search-buckets-list">
+                {% for bucket in buckets %}
+                    {% if bucket.result_count != None %}
+                        <li class="search-buckets__list-item" data-current="{% if bucket.is_current %}true{% else %}false{% endif %}">
+                            <a href="?{% if form.q.value %}q={{ form.q.value }}&{% endif %}group={{ bucket.key }}" class="search-buckets__link" aria-current="{% if bucket.is_current %}true{% else %}false{% endif %}">
+                                {{ bucket.label_with_count }}
+                            </a>
+                        </li>
+                    {%endif%}
+                {% endfor %}
+            </ul>
+        </div>
+    </div>
 </nav>

--- a/templates/search/blocks/search_results_hero.html
+++ b/templates/search/blocks/search_results_hero.html
@@ -1,41 +1,20 @@
 {% load search_tags %}
 
-<div class="search-hero search-hero--has-nav">
-    <h1 class="tna-heading-l search-hero__heading">{{search_tab|search_title}}</h1>
-    <form method="GET" class="search-hero__form tna-!--margin-top-s" data-id="search-form" id="catalogue-search-form">
+<div class="search-hero">
+    <div class="tna-container">
+        <div class="tna-column tna-column--full">
+            <div class="search-hero__container">
+                <h1 class="tna-heading-xl search-hero__heading">{{search_tab|search_title}}</h1>
+                <form method="GET" class="search-hero__form tna-!--margin-top-s" data-id="search-form" id="catalogue-search-form">
+                    <label for="{{form.q.id_for_label}}" class="sr-only">Search term</label>
+                    {{ form.q.errors }}
+                    {{ form.q }}
 
-        <label for="{{form.q.id_for_label}}" class="sr-only">Search term</label>
-        {{ form.q.errors }}
-        {{ form.q }}
+                    {% render_fields_as_hidden form exclude='q' %}
 
-        {% render_fields_as_hidden form exclude='q' %}
-
-        <input type="submit" value="Search" class="search-hero__form-submit">
-    </form>
-
-    {% with request.resolver_match.url_name as url_name  %}
-        <nav class="search-hero__nav" aria-label="Search result types">
-            <ul class="search-hero__nav-list">
-                <li class="search-hero__nav-list-item">
-                    {% if url_name == 'search-featured' %}
-                        <span aria-current="true" class="search-hero__nav-link">{{searchtabs.ALL.value}}</span>
-                    {% else %}
-                    <a class="search-hero__nav-link" href="{% url 'search-featured' %}{% if form.q.value %}?q={{ form.q.value }}{% endif %}">{{searchtabs.ALL.value}}</a>
-                    {% endif %}
-                </li>
-                <li class="search-hero__nav-list-item">
-                    {% if url_name == 'search-catalogue' %}
-                        <span aria-current="true" class="search-hero__nav-link">{{searchtabs.CATALOGUE.value}}</span>
-                    {% else %}
-                    <a class="search-hero__nav-link" href="{% url 'search-catalogue' %}{% if form.q.value %}?q={{ form.q.value }}{% endif %}">{{searchtabs.CATALOGUE.value}}</a>
-                    {% endif %}
-                </li>
-                <li class="search-hero__nav-list-item">
-                    <div>
-                        <a href="/search/featured/" data-link-type="Link" data-link="Start a new search">Start new search</a>
-                    </div>
-                </li>
-            </ul>
-        </nav>
-    {% endwith %}
+                    <input type="submit" value="Search" class="search-hero__form-submit">
+                </form>
+            </div>
+        </div>
+    </div>
 </div>

--- a/templates/search/catalogue_search.html
+++ b/templates/search/catalogue_search.html
@@ -23,21 +23,19 @@
     {{ form.non_field_errors }}
 
     {% with search_tab=searchtabs.CATALOGUE.value %}
-        {% include './blocks/search_results_hero.html' %}
 
-        {% if buckets.current.result_count %}
-            <p class="search-results__explainer">Results for records held at The National Archives and other archives that match your search term.</p>
-        {% endif %}
+        {% include './blocks/search_results_hero.html' %}
 
         {% if buckets_contain_results %}
             {% include './blocks/catalogue_search_buckets.html' %}
         {% endif %}
 
-        {% if buckets.current.result_count > 0 %}
-                
 
+        {% if buckets.current.result_count > 0 %}
             {% include './blocks/search_sort_and_view_options.html' %}
         {% endif %}
+
+
 
         {% if buckets.current.result_count > 0 or form.errors %}
             <div class="catalogue-search-grid" data-id="catalogue-search-grid">


### PR DESCRIPTION
Ticket URL: [HERITAGE-53](https://national-archives.atlassian.net/browse/HERITAGE-53)

## About these changes

Update jumbo tabs on search page to match updated design
Removes top level tabs and new search link
Removes "explainer" sentence above tabs

## How to check these changes

Visit search page `/search/catalogue/` and check that the tabs work and match the design as expected. Functionality is different on smaller screens so this should also be checked

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [x] Ensured that PR includes only commits relevant to the ticket
- [x] Waited for all CI jobs to pass before requesting a review
- [ ] Added/updated tests and documentation where relevant

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)


[HERITAGE-53]: https://national-archives.atlassian.net/browse/HERITAGE-53?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ