### PR TITLE
HERITAGE-95 Update record details table stripe colour

### DIFF
--- a/sass/includes/_record-details.scss
+++ b/sass/includes/_record-details.scss
@@ -12,7 +12,7 @@
         }
 
         tr:nth-child(odd) {
-            background-color: $color__grey-200;
+            background-color: $color__grey-300;
         }
 
         th {


### PR DESCRIPTION
Ticket URL: [HERITAGE-95](https://national-archives.atlassian.net/browse/HERITAGE-95)

## About these changes

Changes to the global page background caused the table stripe to go missing. Setting a darker colour (as per design) resolves this

## How to check these changes

Details page can be found at `/catalogue/id/C8077549/`

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [x] Ensured that PR includes only commits relevant to the ticket
- [x] Waited for all CI jobs to pass before requesting a review
- [ ] Added/updated tests and documentation where relevant

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)


[HERITAGE-95]: https://national-archives.atlassian.net/browse/HERITAGE-95?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ