### PR TITLE
HERITAGE-119 Display filters in a grid on long filters page

### DIFF
--- a/sass/includes/search/_long-filters.scss
+++ b/sass/includes/search/_long-filters.scss
@@ -45,17 +45,17 @@
         &-list {
             padding-left: 0;
             margin-bottom: 0;
+            display: grid;
+            gap: 1rem;
 
             @media only screen and (min-width: #{$screen__md + 1px}) {
-                column-count: 3;
-                column-gap: 1rem;
+                grid-template-columns: repeat(3, minmax(0, 1fr));
+                gap: 2rem;
             }
 
             &-item {
                 list-style: none;
-                margin-right: 4rem;
                 width: 100%;
-                max-width: 20rem;
                 vertical-align: text-top;
             }
         }


### PR DESCRIPTION
Ticket URL: [HERITAGE-119](https://national-archives.atlassian.net/browse/HERITAGE-119)

## About these changes

Change layout from CSS columns to CSS grid to improve reading order and alignment of long filters

## How to check these changes

This can be viewed at `/search/catalogue/long-filter-chooser/collection/`

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [x] Ensured that PR includes only commits relevant to the ticket
- [x] Waited for all CI jobs to pass before requesting a review
- [ ] Added/updated tests and documentation where relevant

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)


[HERITAGE-119]: https://national-archives.atlassian.net/browse/HERITAGE-119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ