### PR TITLE
HERITAGE-126 Add back to search links to container on details page

### DIFF
--- a/sass/includes/_record-cta-panel.scss
+++ b/sass/includes/_record-cta-panel.scss
@@ -3,7 +3,7 @@
     justify-content: space-between;
     font-family: $font__roboto;
     font-size: 1rem;
-    padding: 0 0.5rem;
+    padding-right: 0.5rem;
     margin: 0.75rem 0 0;
 
     @media screen and (min-width: #{$screen__sm + 1px}) {
@@ -12,7 +12,7 @@
 
     &__link {
         display: inline-flex;
-        padding: 0.5rem 0.5rem 0.25rem 1rem;
+        padding: 0.5rem 0.5rem 0.25rem 0;
         font-family: $font__supria-sans;
         font-size: 1.1rem;
         text-align: center;

--- a/templates/includes/records/record-cta-panel.html
+++ b/templates/includes/records/record-cta-panel.html
@@ -1,6 +1,10 @@
 {% load records_tags %}
 
-<div class="cta-primary-panel">
-    <a class="cta-primary-panel__link" href="{{ back_to_search_url }}" data-link-type="Link" data-link="Back to search results" data-component-name="Navigation">{% include "includes/icon.html" with name="chevron-left" classname="cta-primary-panel__link-icon" %}Back to search results</a>
-    <a class="cta-primary-panel__link" href="{% url 'search' %}" data-link-type="Link" data-link="Start a new search" data-component-name="Navigation">{% include "includes/icon.html" with name="search" classname="cta-primary-panel__link-icon" %}Start a new search</a>
+<div class="tna-container">
+    <div class="tna-column tna-column--full">
+        <div class="cta-primary-panel">
+            <a class="cta-primary-panel__link" href="{{ back_to_search_url }}" data-link-type="Link" data-link="Back to search results" data-component-name="Navigation">{% include "includes/icon.html" with name="chevron-left" classname="cta-primary-panel__link-icon" %}Back to search results</a>
+            <a class="cta-primary-panel__link" href="{% url 'search' %}" data-link-type="Link" data-link="Start a new search" data-component-name="Navigation">{% include "includes/icon.html" with name="search" classname="cta-primary-panel__link-icon" %}Start a new search</a>
+        </div>
+    </div>
 </div>

--- a/templates/records/record_detail.html
+++ b/templates/records/record_detail.html
@@ -12,13 +12,15 @@
 
     {% include "includes/records/record-cta-panel.html" %}
 
-    <div class="container">
-        {% include "includes/records/record-title.html" %}
+    <div class="tna-container">
+        <div class="tna-column tna-column--full">
+            {% include "includes/records/record-title.html" %}
 
-        <h2 id="record-details-heading" class="tna-heading-l">Description and record details</h2>
+            <h2 id="record-details-heading" class="tna-heading-l">Description and record details</h2>
 
-        {# If there are no related tags to display #}
-        {% include "includes/records/record-details.html" %}
+            {# If there are no related tags to display #}
+            {% include "includes/records/record-details.html" %}
+        </div>
     </div>
 
     {# If there are related tags to display #}
@@ -32,14 +34,16 @@
         </div>
     </div>
 
-    <div class="container">
-        {% if record.hierarchy %}
-            {% if record.hierarchy|length > 2 %}
-                <h2 class="tna-heading-l">This record is in the series</h2>
+    <div class="tna-container">
+        <div class="tna-column tna-column--full">
+            {% if record.hierarchy %}
+                {% if record.hierarchy|length > 2 %}
+                    <h2 class="tna-heading-l">This record is in the series</h2>
 
-                {% include "includes/records/record-series-panel.html" %}
+                    {% include "includes/records/record-series-panel.html" %}
+                {% endif %}
             {% endif %}
-        {% endif %}
+        </div>
     </div>
 
 {% endblock %}


### PR DESCRIPTION
Ticket URL: [HERITAGE-126](https://national-archives.atlassian.net/browse/HERITAGE-126)

## About these changes

Add "back to search" and "start a new search" links to TNA container on details pages
Adds correct `tna-container` to elements that previously used `container`

## How to check these changes

Details page can be found here `/catalogue/id/C8077549/`. Links are at the top of the page above the "You are viewing the catalogue description of the following item:" label

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [x] Ensured that PR includes only commits relevant to the ticket
- [ ] Waited for all CI jobs to pass before requesting a review
- [ ] Added/updated tests and documentation where relevant

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)


[HERITAGE-126]: https://national-archives.atlassian.net/browse/HERITAGE-126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ