### PR TITLE
HERITAGE-135: Filters

### DIFF
--- a/etna/ciim/tests/test_client.py
+++ b/etna/ciim/tests/test_client.py
@@ -221,8 +221,8 @@ class ClientSearchTest(SimpleTestCase):
         self.assertEqual(
             responses.calls[0].request.url,
             f"{settings.CLIENT_BASE_URL}/search?"
-            "filter=collection%3Avalue1%3Aor"
-            "&filter=collection%3Avalue2%3Aor",
+            "filter=collection%3Avalue1"
+            "&filter=collection%3Avalue2",
         )
 
     @responses.activate

--- a/etna/ciim/utils.py
+++ b/etna/ciim/utils.py
@@ -287,7 +287,7 @@ def prepare_filter_aggregations(items: Optional[list]) -> Optional[str]:
     subst = " "
     field_list_to_prepare = ["heldBy"]
     filter_prepared_list = []
-    fields_using_or_operator = ["heldBy", "collection", "level"]
+    fields_using_or_operator = ["heldBy", "level"]
 
     for item in items:
         field, value = item.split(":", 1)

--- a/etna/ciim/utils.py
+++ b/etna/ciim/utils.py
@@ -263,3 +263,60 @@ def strip_html(value: str, preserve_marks=False):
     if preserve_marks:
         tags.append("mark")
     return mark_safe(bleach.clean(value, tags=tags, strip=True))
+
+
+def prepare_filter_aggregations(items: Optional[list]) -> Optional[str]:
+    """
+    Filter format in items: 'field:value', 'field:value:or'
+    Prepares i.e. removes/replaces special chars from a filter fields' value to be passed to the api
+    When using filter with multiple values, specific fields require OR operator to be specified,
+    otherwise AND is used by default.
+    Example:
+    before-prepare: "heldBy:Birmingham: Archives, Heritage and Photography Service"
+    after-prepare:  "heldBy:Birmingham Archives Heritage and Photography Service"
+    before-prepare: "heldBy:Staffordshire and Stoke-on-Trent Archive Service: Staffordshire County Record Office"
+    after-prepare:  "heldBy:Staffordshire and Stoke on Trent Archive Service Staffordshire County Record Office"
+    Special char single quote i.e. ' is not prepared
+    before-prepare: "heldBy:Labour History Archive and Study Centre (People's History Museum/University of Central Lancashire)"
+    after-prepare:  "heldBy:Labour History Archive and Study Centre People's History Museum University of Central Lancashire "
+    """
+    if not items:
+        return []
+
+    regex = r"([/():,\&\-\|+@!.])"
+    subst = " "
+    field_list_to_prepare = ["heldBy"]
+    filter_prepared_list = []
+    fields_using_or_operator = ["heldBy", "collection", "level"]
+
+    for item in items:
+        field, value = item.split(":", 1)
+        if field in field_list_to_prepare:
+            # replace special chars
+            prepared_value = re.sub(regex, subst, value, 0, re.MULTILINE)
+            # replace multiple space
+            prepared_value = re.sub(" +", subst, prepared_value, 0, re.MULTILINE)
+            filter_prepared = (
+                field + ":" + re.sub(regex, subst, prepared_value, 0, re.MULTILINE)
+            )
+        else:
+            filter_prepared = field + ":" + value
+
+        filter_prepared_list.append(filter_prepared)
+
+    # if number of occurrences of field_for_or is more than 1, update add or to those values
+    # ["collection:<value1>:or", "collection:<value2>:or", "group:<value3>"]
+    for field in fields_using_or_operator:
+        # more than 1 value for the field
+        if sum((item.split(":", 1)[0].count(field) for item in items)) > 1:
+            # append or to the value for each field
+            updated_list_for_or_operator = []
+            for item in filter_prepared_list:
+                if item.split(":", 1)[0] == field:
+                    updated_list_for_or_operator.append(item + ":or")
+                else:
+                    updated_list_for_or_operator.append(item)
+
+            filter_prepared_list = updated_list_for_or_operator
+
+    return filter_prepared_list


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/HERITAGE-135

## About these changes
- API is updated internally to reflect queries made with multiple values of the same filter and across filters
- removed OR operator for collection API query for Community agg, as per Rosetta API updates
- relocated prep filter aggregations to utils

## How to check these changes

- Query with single values for each filter
- Query with multiple values for each filter
- Query across filters combinations
- Filters Community bucket  : http://127.0.0.1:8000/search/catalogue/

Ex: 
http://127.0.0.1:8000/search/catalogue/?covering_date_from_0=&covering_date_from_1=&covering_date_from_2=1980&covering_date_to_0=&covering_date_to_1=&covering_date_to_2=1999&collection=SWOP&place=Church+Street&q=&sort=&group=community


## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [x] Ensured that PR includes only commits relevant to the ticket
- [x] Waited for all CI jobs to pass before requesting a review
- [x] Added/updated tests and documentation where relevant

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
