### PR TITLE
HERITAGE-196:update attribute

### DIFF
--- a/etna/records/field_labels.py
+++ b/etna/records/field_labels.py
@@ -47,7 +47,7 @@ FIELD_LABELS = {
     "rights": "Rights",
     "format": "Format",
     "location": "Location",
-    "subject": "Subject",
+    "subjects": "Subject",
     "level": "Level",
     "type": "Type",
     "identifier": "Identifier",

--- a/etna/records/models.py
+++ b/etna/records/models.py
@@ -636,8 +636,8 @@ class Record(DataLayerMixin, APIModel):
         return self.template.get("rights", "")
 
     @cached_property
-    def subject(self) -> list(str):
-        return self.template.get("subject", [])
+    def subjects(self) -> list(str):
+        return self.template.get("subjects", [])
 
     @cached_property
     def ciim_url(self) -> str:

--- a/etna/records/tests/test_models.py
+++ b/etna/records/tests/test_models.py
@@ -38,7 +38,7 @@ class DefaultReturnsRecordModelTests(SimpleTestCase):
         self.assertEqual(self.record.collection_id, "")
         self.assertEqual(self.record.collection_url, "")
         self.assertEqual(self.record.rights, "")
-        self.assertEqual(self.record.subject, [])
+        self.assertEqual(self.record.subjects, [])
 
 
 class CommunityRecordModelTests(SimpleTestCase):

--- a/templates/includes/records/record-details-community.html
+++ b/templates/includes/records/record-details-community.html
@@ -54,12 +54,12 @@
         <td>{{ record.location }}</td>
     </tr>
 {% endif %}
-{% if record.subject %}
+{% if record.subjects %}
     <tr>
-        <th scope="row">{{ 'subject'|as_label }}</th>
+        <th scope="row">{{ 'subjects'|as_label }}</th>
         <td>
-            {% for sub in record.subject %}
-                <p>{{ sub }}</p>
+            {% for subject in record.subjects %}
+                <p>{{ subject }}</p>
             {% endfor %}
         </td>
     </tr>


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/HERITAGE-196

## About these changes

Following changes made for OSC records to return list(str) instead of str
- Update attribute name subject -> subjects 

## How to check these changes

http://127.0.0.1:8000/catalogue/id/osc-16002/
http://127.0.0.1:8000/catalogue/id/pcw-41083/

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [x] Ensured that PR includes only commits relevant to the ticket
- [x] Waited for all CI jobs to pass before requesting a review
- [x] Added/updated tests and documentation where relevant

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
