### PR TITLE
HERITAGE-207: Allow anchor and new line tags

### DIFF
--- a/etna/ciim/utils.py
+++ b/etna/ciim/utils.py
@@ -264,6 +264,7 @@ def strip_html(value: str, preserve_marks=False, allow_tags=None):
         tags.append("mark")
     return bleach.clean(value, tags=tags, strip=True)
 
+
 def prepare_filter_aggregations(items: Optional[list]) -> Optional[str]:
     """
     Filter format in items: 'field:value', 'field:value:or'

--- a/etna/ciim/utils.py
+++ b/etna/ciim/utils.py
@@ -3,7 +3,6 @@ import re
 from typing import Any, Dict, Optional
 
 from django.urls import NoReverseMatch, reverse
-from django.utils.safestring import mark_safe
 
 import bleach
 

--- a/etna/ciim/utils.py
+++ b/etna/ciim/utils.py
@@ -258,12 +258,11 @@ def format_link(link_html: str) -> Dict[str, str]:
     return {"href": href, "id": id, "text": document.text()}
 
 
-def strip_html(value: str, preserve_marks=False):
-    tags = []
+def strip_html(value: str, preserve_marks=False, allow_tags=None):
+    tags = allow_tags or []
     if preserve_marks:
         tags.append("mark")
-    return mark_safe(bleach.clean(value, tags=tags, strip=True))
-
+    return bleach.clean(value, tags=tags, strip=True)
 
 def prepare_filter_aggregations(items: Optional[list]) -> Optional[str]:
     """

--- a/etna/records/models.py
+++ b/etna/records/models.py
@@ -213,9 +213,15 @@ class Record(DataLayerMixin, APIModel):
         """
         Returns the records full description value with all HTML left intact.
         """
-        # TODO:Rosetta
-        # return mark_safe(self._get_raw_description())
-        return self._get_raw_description()
+        if raw := self._get_raw_description():
+            if self.group == BucketKeys.COMMUNITY:
+                allow_tags = ['a', 'br']
+                updated_value = raw.replace('\n','<br />' )
+                return mark_safe(strip_html(updated_value, allow_tags=allow_tags))
+            # TODO:Rosetta
+            # return mark_safe(raw)
+            return raw
+        return ""
 
     @cached_property
     def listing_description(self) -> str:
@@ -224,10 +230,12 @@ class Record(DataLayerMixin, APIModel):
         anywhere. When highlight data is provided by the API, <mark> tags
         will be left in-tact, but and other HTML is stripped.
         """
+        if self.group == BucketKeys.COMMUNITY:
+            # TODO:Rosetta when we know about highlights, marks
+            return self.description
+        # TODO:Rosetta tna,nonTna
         if raw := self._get_raw_description(use_highlights=True):
-            # TODO:Rosetta
-            # return mark_safe(strip_html(raw, preserve_marks=True))
-            return raw
+            return mark_safe(strip_html(raw, preserve_marks=True))
         return ""
 
     def _get_raw_description(self, use_highlights: bool = False) -> str:

--- a/etna/records/models.py
+++ b/etna/records/models.py
@@ -215,9 +215,10 @@ class Record(DataLayerMixin, APIModel):
         """
         if raw := self._get_raw_description():
             if self.group == BucketKeys.COMMUNITY:
-                allow_tags = ['a', 'br']
-                updated_value = raw.replace('\n','<br />' )
-                return mark_safe(strip_html(updated_value, allow_tags=allow_tags))
+                allow_tags = ["a", "br", "p"]
+                updated_value = raw.replace("\n", "<br />")
+                strip_html_value = strip_html(updated_value, allow_tags=allow_tags)
+                return mark_safe(strip_html_value)
             # TODO:Rosetta
             # return mark_safe(raw)
             return raw

--- a/etna/records/tests/test_models.py
+++ b/etna/records/tests/test_models.py
@@ -42,6 +42,7 @@ class DefaultReturnsRecordModelTests(SimpleTestCase):
 
 
 class CommunityRecordModelTests(SimpleTestCase):
+    maxDiff = None
     fixture_path = f"{settings.BASE_DIR}/etna/ciim/tests/fixtures/record_community.json"
 
     @classmethod
@@ -65,6 +66,20 @@ class CommunityRecordModelTests(SimpleTestCase):
 
     def test_uuid(self):
         self.assertEqual(self.record.uuid, "f4a6014d-cf22-3a88-ba1b-765622f25319")
+
+    def test_description(self):
+        self.assertEqual(self.record.description, "data for description")
+
+    def test_description_contains_html(self):
+        # patch raw data
+        value_contains_html = '<b> in bold </b> <p> in para </p><span>in span<a href="http://test.com">atag</a></span><custom>custom tag</custom>\nline2'
+        self.record._raw["@template"]["details"].update(
+            {"description": value_contains_html}
+        )
+        self.assertEqual(
+            self.record.description,
+            ' in bold  <p> in para </p>in span<a href="http://test.com">atag</a>custom tag<br>line2',
+        )
 
     def test_group(self):
         self.assertEqual(self.record.group, "community")


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/HERITAGE-207

## About these changes

Allow anchor, new lines into HTML

## How to check these changes

http://127.0.0.1:8000/search/catalogue/?q=1944+airfield&collection=People%27s+Collection+Wales&covering_date_from_0=&covering_date_from_1=&covering_date_from_2=&covering_date_to_0=&covering_date_to_1=&covering_date_to_2=&per_page=20&sort=&display=list&group=community

http://127.0.0.1:8000/catalogue/id/pcw-42868/


## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [x] Ensured that PR includes only commits relevant to the ticket
- [x] Waited for all CI jobs to pass before requesting a review
- [x] Added/updated tests and documentation where relevant

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
