### PR TITLE
HERITAGE-262: Integrate search results with enrichment tag data

### DIFF
--- a/etna/ciim/constants.py
+++ b/etna/ciim/constants.py
@@ -664,6 +664,16 @@ class VisViews(StrEnum):
 
 
 @forTemplate
+class TagTypes(StrEnum):
+    """Tag types values defined by @template.details.enrichment keys"""
+
+    LOCATION = "loc"
+    PERSON = "per"
+    ORGANISATION = "org"
+    MISCELLANEOUS = "misc"
+
+
+@forTemplate
 class TimelineTypes(StrEnum):
     """The timeline view types that can be displayed"""
 

--- a/etna/records/models.py
+++ b/etna/records/models.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import re
 
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from django.conf import settings
 from django.http import HttpRequest
@@ -14,7 +14,7 @@ from django.utils.safestring import mark_safe
 from pyquery import PyQuery as pq
 
 from ..analytics.mixins import DataLayerMixin
-from ..ciim.constants import BucketKeys
+from ..ciim.constants import BucketKeys, TagTypes
 from ..ciim.models import APIModel
 from ..ciim.utils import (
     NOT_PROVIDED,
@@ -673,3 +673,53 @@ class Record(DataLayerMixin, APIModel):
     @cached_property
     def item_url(self) -> str:
         return self.template.get("itemURL", "")
+
+    def _get_tags(self, tag_type: str) -> List[Dict]:
+        """
+        Returns the data in the value attribute for the tag type when present
+        in the enrichment otherwise empty list.
+
+        tag_type:
+            values which are defined by API response @template.details.enrichment keys,
+            which are known at constants.TagTypes
+        """
+        return_value = []
+        if tag := extract(self.template, f"enrichment.{tag_type}", default=[]):
+            for item in tag:
+                data = {}
+                if value := item.get("value", ""):
+                    data.update(value=value)
+                if data:
+                    return_value.append(data)
+        return return_value
+
+    @cached_property
+    def has_enrichment(self) -> bool:
+        """
+        Returns True if the record is enriched, otherwise False.
+        Enrichment is determined if data-value,url exists for a set of tag types.
+        """
+        if (
+            self.enrichment_loc
+            or self.enrichment_per
+            or self.enrichment_org
+            or self.enrichment_misc
+        ):
+            return True
+        return False
+
+    @cached_property
+    def enrichment_loc(self) -> List[Dict]:
+        return self._get_tags(TagTypes.LOCATION)
+
+    @cached_property
+    def enrichment_per(self):
+        return self._get_tags(TagTypes.PERSON)
+
+    @cached_property
+    def enrichment_org(self):
+        return self._get_tags(TagTypes.ORGANISATION)
+
+    @cached_property
+    def enrichment_misc(self):
+        return self._get_tags(TagTypes.MISCELLANEOUS)

--- a/etna/records/models.py
+++ b/etna/records/models.py
@@ -678,6 +678,7 @@ class Record(DataLayerMixin, APIModel):
         """
         Returns the data in the value attribute for the tag type when present
         in the enrichment otherwise empty list.
+        [{"value": <some value 1>},{"value": <some value 2>}]
 
         tag_type:
             values which are defined by API response @template.details.enrichment keys,

--- a/etna/search/tests/fixtures/catalogue_search_having_enrichment_tags.json
+++ b/etna/search/tests/fixtures/catalogue_search_having_enrichment_tags.json
@@ -1,0 +1,106 @@
+{
+    "data": [
+        {
+            "@template": {
+                "details": {
+                    "level": "item",
+                    "description": "the northern bank of the river Thames, looking NE",
+                    "summary": "View of the figurehead of the Upper Thames Sailing Club, originally from the battleship 'Vengeance'. Bourne End, Wooburn. 1936",
+                    "title": "View of the figurehead of the Upper Thames Sailing Club, originally from the battleship 'Vengeance'. Bourne End, Wooburn. 1936",
+                    "uuid": "4dae30e8-9fb5-3264-955b-f50cbef2357c",
+                    "creationDateTo": "1936",
+                    "creationDateFrom": "1936",
+                    "creationDate": "1936",
+                    "collection": "SWOP",
+                    "collectionId": "swop-0",
+                    "format": "Photo Print",
+                    "ciimId": "swop-49008",
+                    "group": "community",
+                    "status": "publish",
+                    "repository": "High Wycombe Library",
+                    "enrichment": {
+                        "date": [
+                            {
+                                "from": "1936",
+                                "to": "1936",
+                                "value": "1936"
+                            },
+                            {
+                                "from": "1925",
+                                "to": "1925",
+                                "value": "1925"
+                            }
+                        ],
+                        "loc": [
+                            {
+                                "value": "Bourne End",
+                                "url": "https://www.wikidata.org/wiki/Q2059003"
+                            },
+                            {
+                                "value": "Wooburn",
+                                "url": "https://www.wikidata.org/wiki/Q2740404"
+                            },
+                            {
+                                "value": "Britannia",
+                                "url": "https://www.wikidata.org/wiki/Q138396"
+                            }
+                        ],
+                        "org": [
+                            {
+                                "value": "Upper Thames Sailing Club"
+                            }
+                        ],
+                        "per": [
+                            {
+                                "value": "Arthur Jackson"
+                            }
+                        ],
+                        "misc": [
+                            {
+                                "value": "Vengeance"
+                            }
+                        ]
+                    },
+                    "subjects": [
+                        "Monument",
+                        "Memorial",
+                        "Trophy"
+                    ]
+                }
+            }
+        }
+    ],
+    "errors": [],
+    "aggregations": [
+        {
+            "name": "collection",
+            "entries": [
+                {
+                    "value": "SWOP",
+                    "doc_count": 1
+                }
+            ]
+        },
+        {
+            "name": "place",
+            "entries": []
+        },
+        {
+            "name": "group",
+            "entries": [
+                {
+                    "value": "community",
+                    "doc_count": 1
+                }
+            ]
+        }
+    ],
+    "stats": {
+        "total": 1,
+        "providers": 1,
+        "transformations": 1,
+        "provider_latency": 6,
+        "transformation_latency": 3
+    },
+    "found": true
+}

--- a/etna/search/tests/test_views.py
+++ b/etna/search/tests/test_views.py
@@ -489,6 +489,37 @@ class CatalogueSearchEndToEndTest(EndToEndSearchTestCase):
                 content,
             )
 
+    @responses.activate
+    def test_search_results_having_enrichment_tags(self):
+
+        self.patch_search_endpoint("catalogue_search_having_enrichment_tags.json")
+
+        expected_url = "/search/catalogue/?q=swop-49008&group=community&collection=SWOP&vis_view=list"
+
+        response = self.client.get(
+            self.test_url,
+            data={
+                "q": "swop-49008",
+                "group": "community",
+                "collection": [
+                    "SWOP",
+                ],
+                "vis_view": "list",
+            },
+        )
+        session = self.client.session
+        content = str(response.content)
+
+        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(session.get("back_to_search_url"), expected_url)
+
+        self.assertIn('<span class="ohos-tag__inner">Bourne End</span>', content)
+        self.assertIn('<span class="ohos-tag__inner">Arthur Jackson</span>', content)
+        self.assertIn(
+            '<span class="ohos-tag__inner">Upper Thames Sailing Club</span>', content
+        )
+        self.assertIn('<span class="ohos-tag__inner">Vengeance</span>', content)
+
 
 @unittest.skip("TODO:Rosetta")
 class CatalogueSearchLongFilterChooserAPIIntegrationTest(SearchViewTestCase):

--- a/templates/includes/tags.html
+++ b/templates/includes/tags.html
@@ -1,37 +1,38 @@
 {% comment %}
-    Tags are part of the search results cards. We don't have the data to display for the
-    cards yet, but mark up and styles have been created ahead of integration. These will
-    be shown conditionally when digital community content is displayed
+    NOTE: Order of the tag types is Location, Person, Organisation, Miscellaneous
 {% endcomment %}
+{% if record.has_enrichment %}
+    <ul class="search-results__tags-list">
+        {% if record.enrichment_loc.0.value %} 
+            <li>
+                <span class="ohos-tag ohos-tag--location">
+                    <span class="ohos-tag__inner">{{ record.enrichment_loc.0.value }}</span>
+                </span>
+            </li>
+        {% endif %}
 
-<ul class="search-results__tags-list">
-    <li>
-        <span class="ohos-tag ohos-tag--location">
-            <span class="ohos-tag__inner">Location</span>
-        </span>
-    </li>
+        {% if record.enrichment_per.0.value %} 
+            <li>
+                <span class="ohos-tag ohos-tag--person">
+                    <span class="ohos-tag__inner">{{ record.enrichment_per.0.value }}</span>
+                </span>
+            </li>
+        {% endif %}
 
-    <li>
-        <span class="ohos-tag ohos-tag--person">
-            <span class="ohos-tag__inner">Person</span>
-        </span>
-    </li>
+        {% if record.enrichment_org.0.value %} 
+            <li>
+                <span class="ohos-tag ohos-tag--organisation">
+                    <span class="ohos-tag__inner">{{ record.enrichment_org.0.value }}</span>
+                </span>
+            </li>
+        {% endif %}
 
-    <li>
-        <span class="ohos-tag ohos-tag--organisation">
-            <span class="ohos-tag__inner">Organisation</span>
-        </span>
-    </li>
-
-    <li>
-        <span class="ohos-tag ohos-tag--misc">
-            <span class="ohos-tag__inner">Miscellaneous</span>
-        </span>
-    </li>
-
-    <li>
-        <span class="ohos-tag ohos-tag--other">
-            <span class="ohos-tag__inner">Other</span>
-        </span>
-    </li>
-</ul>
+        {% if record.enrichment_misc.0.value %} 
+            <li>
+                <span class="ohos-tag ohos-tag--misc">
+                    <span class="ohos-tag__inner">{{ record.enrichment_misc.0.value }}</span>
+                </span>
+            </li>
+        {% endif %}
+    </ul>
+{% endif %}


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/HERITAGE-262

## About these changes

- Integrates API response named entities in the search results
- Location, Person, Organisation, Miscellaneous will be populated with enriched data (max 1 value) when present
- Other - tag is no longer needed, hence removed.
- Added tests

## How to check these changes

Tags are present for Collection-SWOP / swop-49008
http://127.0.0.1:8000/search/catalogue/?q=swop-49008&group=community&vis_view=list
http://127.0.0.1:8000/search/catalogue/?q=swop-49008&group=community&vis_view=timeline
http://127.0.0.1:8000/search/catalogue/?q=swop-49008&group=community&vis_view=tag

Tags not present for Collection-People's Collection Wales
http://127.0.0.1:8000/search/catalogue/?&collection=People%27s+Collection+Wales&vis_view=list&group=community

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [x] Ensured that PR includes only commits relevant to the ticket
- [x] Waited for all CI jobs to pass before requesting a review
- [x] Added/updated tests and documentation where relevant

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
