### PR TITLE
HERITAGE-267 truncate item descriptions in search results cards

### DIFF
--- a/templates/search/blocks/search_results__list-card.html
+++ b/templates/search/blocks/search_results__list-card.html
@@ -9,7 +9,7 @@
     <div class="search-results__list-card-details">
         <h3 class="tna-heading-m">
             <a href="{% record_url record level_or_archive=record.level form_group=form.group.value %}" class="search-results__list-card-heading-link" data-link="{{ record.reference_prefixed_summary_title }}" data-link-type="Search results list" search-bucket="{{ buckets.current.label }}">
-                {% if form.group.value == bucketkeys.COMMUNITY.value %} 
+                {% if form.group.value == bucketkeys.COMMUNITY.value %}
                     {% if record.ciim_id %}
                         <span class="sr-only">CIIM Id {{ record.ciim_id }}: </span>
                     {% endif %}
@@ -23,7 +23,7 @@
         </h3>
 
         <p class="search-results__list-card-description">
-            {{ record.listing_description }}
+            {{ record.listing_description|truncatechars_html:250 }}
         </p>
 
         <dl class="tna-dl tna-dl--plain tna-!--margin-bottom-s">
@@ -37,6 +37,6 @@
         {% if form.group.value == bucketkeys.COMMUNITY.value %}
             {% include 'includes/tags.html' %}
         {% endif %}
-        
+
     </div>
 </li>


### PR DESCRIPTION
Ticket URL: [HERITAGE-267](https://national-archives.atlassian.net/browse/HERITAGE-267)

## About these changes

Truncate item descriptions in search results cards, ensures HTML elements are closed properly

## How to check these changes

Search results cards can be found at `/search/catalogue/`

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [x] Ensured that PR includes only commits relevant to the ticket
- [x] Waited for all CI jobs to pass before requesting a review
- [ ] Added/updated tests and documentation where relevant

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)


[HERITAGE-267]: https://national-archives.atlassian.net/browse/HERITAGE-267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ