### PR TITLE
HERITAGE-298 Make related-tags 'sections' conditional

### DIFF
--- a/templates/includes/related-tags.html
+++ b/templates/includes/related-tags.html
@@ -6,20 +6,11 @@
     <h3>Related tags</h3>
 
     <dl class="record-details__related-tags-list">
-        <dt>Locations:</dt>
-        {% include 'includes/tags-wiki.html' with tag=record.enrichment_loc css_extn_style="location" %}
-
-        <dt>People:</dt>
-        {% include 'includes/tags-wiki.html' with tag=record.enrichment_per css_extn_style="person" %}
-
-        <dt>Organisations:</dt>
-        {% include 'includes/tags-wiki.html' with tag=record.enrichment_org css_extn_style="organisation" %}
-
-        <dt>Miscellaneous:</dt>
-        {% include 'includes/tags-wiki.html' with tag=record.enrichment_misc css_extn_style="misc" %}
-
-        <dt>Date:</dt>
-        {% include 'includes/tags-wiki.html' with tag=record.enrichment_date css_extn_style="other" %}
+        {% include 'includes/tags-wiki.html' with tag=record.enrichment_loc label="Locations" css_extn_style="location" %}
+        {% include 'includes/tags-wiki.html' with tag=record.enrichment_per label="People" css_extn_style="person" %}
+        {% include 'includes/tags-wiki.html' with tag=record.enrichment_org label="Organisations" css_extn_style="organisation" %}
+        {% include 'includes/tags-wiki.html' with tag=record.enrichment_misc label="Miscellaneous" css_extn_style="misc" %}
+        {% include 'includes/tags-wiki.html' with tag=record.enrichment_date label="Date" css_extn_style="other" %}
     </dl>
 
     <p class="record-details__related-tags-warning"><i class="ohos-search-results-map__info-icon fa-solid fa-circle-info fa-2xl"></i>Related tags are generated using artificial intelligence and may include errors</p>

--- a/templates/includes/tags-wiki.html
+++ b/templates/includes/tags-wiki.html
@@ -1,13 +1,20 @@
-{% for item in tag|slice:":5" %}
-    <dd>
-        <span class="ohos-tag ohos-tag--{{ css_extn_style }}">                
-            <span class="ohos-tag__inner">{{ item.value }}</span>
-            {% if item.url %}
-                <a href="{{ item.url }}" target="_blank" class="ohos-tag__link">
-                    Wikidata
-                    <i aria-hidden="true" class="ohos-tag__link-icon fa-solid fa-external-link"></i>
-                </a>
-            {% endif %}
-        </span>
-    </dd>
-{% endfor %}
+
+{% if tag %}
+    {% if label %}
+        <dt>{{ label }}:</dt>
+    {% endif %}
+
+    {% for item in tag|slice:":5" %}
+        <dd>
+            <span class="ohos-tag ohos-tag--{{ css_extn_style }}">
+                <span class="ohos-tag__inner">{{ item.value }}</span>
+                {% if item.url %}
+                    <a href="{{ item.url }}" target="_blank" class="ohos-tag__link">
+                        Wikidata
+                        <i aria-hidden="true" class="ohos-tag__link-icon fa-solid fa-external-link"></i>
+                    </a>
+                {% endif %}
+            </span>
+        </dd>
+    {% endfor %}
+{% endif %}


### PR DESCRIPTION
Ticket URL: [HERITAGE-298](https://national-archives.atlassian.net/browse/HERITAGE-298)

## About these changes

Move tag term to the same partial that contains the tags loop and add condition to only render label if tags exist

## How to check these changes

Example page `/catalogue/id/swop-7960/`. Related tags are displayed on the right column. Labels should only display when tags are present

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [x] Ensured that PR includes only commits relevant to the ticket
- [x] Waited for all CI jobs to pass before requesting a review
- [ ] Added/updated tests and documentation where relevant

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)


[HERITAGE-298]: https://national-archives.atlassian.net/browse/HERITAGE-298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ