### PR TITLE
HERITAGE-297: add, update BE API attributes

### DIFF
--- a/etna/ciim/tests/fixtures/record_community.json
+++ b/etna/ciim/tests/fixtures/record_community.json
@@ -79,7 +79,10 @@
                 "subject": [
                     "subject1",
                     "subject2"
-                ]
+                ],
+                "creator": "data for creator",
+                "provenance": "data for provenance",
+                "place of deposit":  {"repository": "data for repository"}
             }
         }
     },

--- a/etna/records/field_labels.py
+++ b/etna/records/field_labels.py
@@ -51,4 +51,7 @@ FIELD_LABELS = {
     "level": "Level",
     "type": "Type",
     "identifier": "Identifier",
+    "provenance": "Provenance",
+    "creator": "Creator",
+    "place_of_deposit": "Place of deposit",
 }

--- a/etna/records/models.py
+++ b/etna/records/models.py
@@ -223,7 +223,7 @@ class Record(DataLayerMixin, APIModel):
                 swop_description = (
                     self._description_place() + " " + self._description_view()
                 )
-                return swop_description.lstrip()
+                return swop_description.strip()
 
             allow_tags = {"a", "br", "p"}
             updated_value = raw.replace("\n", "<br />")

--- a/etna/records/models.py
+++ b/etna/records/models.py
@@ -214,17 +214,25 @@ class Record(DataLayerMixin, APIModel):
     def description(self) -> str:
         """
         Returns the records full description value with all HTML left intact.
+
+        Returns other description fields for SWOP
         """
-        if raw := self._get_raw_description():
-            if self.group == BucketKeys.COMMUNITY:
-                allow_tags = {"a", "br", "p"}
-                updated_value = raw.replace("\n", "<br />")
-                strip_html_value = strip_html(updated_value, allow_tags=allow_tags)
-                return mark_safe(strip_html_value)
-            # TODO:Rosetta
-            # return mark_safe(raw)
-            return raw
-        return ""
+        raw = self._get_raw_description()
+        if self.group == BucketKeys.COMMUNITY:
+            if self._is_swop():
+                swop_description = (
+                    self._description_place() + " " + self._description_view()
+                )
+                return swop_description.lstrip()
+
+            allow_tags = {"a", "br", "p"}
+            updated_value = raw.replace("\n", "<br />")
+            strip_html_value = strip_html(updated_value, allow_tags=allow_tags)
+            return mark_safe(strip_html_value)
+
+        # TODO:Rosetta
+        # return mark_safe(raw)
+        return raw
 
     @cached_property
     def listing_description(self) -> str:
@@ -508,8 +516,10 @@ class Record(DataLayerMixin, APIModel):
         return extract(self.get("@template", {}), "details.closureStatus", default="")
 
     @cached_property
-    def creator(self) -> list(str):
-        return self.template.get("creator", [])
+    def creator(self) -> Tuple[str] | str:
+        if self.group == BucketKeys.COMMUNITY:
+            return self.template.get("creator", "")
+        return self.template.get("creator", ())
 
     @cached_property
     def dimensions(self) -> str:
@@ -749,3 +759,21 @@ class Record(DataLayerMixin, APIModel):
     @cached_property
     def enrichment_date(self):
         return self._get_tags(TagTypes.DATE)
+
+    @cached_property
+    def provenance(self) -> str:
+        return self.template.get("provenance", "")
+
+    def _is_swop(self) -> bool:
+        """Returns True if ciim_id identified with SWOP"""
+        return bool(self.ciim_id[:4] == "swop")
+
+    def _description_view(self) -> str:
+        return self.template.get("descriptionView", "")
+
+    def _description_place(self) -> str:
+        return self.template.get("descriptionPlace", "")
+
+    @cached_property
+    def place_of_deposit(self) -> Dict:
+        return self.template.get("place of deposit", {})

--- a/etna/records/tests/test_models.py
+++ b/etna/records/tests/test_models.py
@@ -241,6 +241,37 @@ class CommunityRecordModelTests(SimpleTestCase):
             ],
         )
 
+    def test_description_for_swop(self):
+        self.record._raw["@template"]["details"]["ciimId"] = "swop-1234"
+        self.record._raw["@template"]["details"][
+            "descriptionPlace"
+        ] = "data for descriptionPlace"
+        self.record._raw["@template"]["details"][
+            "descriptionView"
+        ] = "data for descriptionView"
+        self.assertEqual(
+            self.record.description,
+            "data for descriptionPlace" + " " + "data for descriptionView",
+        )
+
+    def test_description_for_swop_partial_data(self):
+        self.record._raw["@template"]["details"]["ciimId"] = "swop-1234"
+        self.record._raw["@template"]["details"][
+            "descriptionView"
+        ] = "data for descriptionView"
+        self.assertEqual(self.record.description, "data for descriptionView")
+
+    def test_provenance(self):
+        self.assertEqual(self.record.provenance, "data for provenance")
+
+    def test_creator(self):
+        self.assertEqual(self.record.creator, "data for creator")
+
+    def test_place_of_deposit(self):
+        self.assertEqual(
+            self.record.place_of_deposit, {"repository": "data for repository"}
+        )
+
 
 @unittest.skip("TODO:Rosetta")
 class RecordModelTests(SimpleTestCase):


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/HERITAGE-297

## About these changes

Added, Updated BE API attributes

## How to check these changes

Details page:
http://127.0.0.1:8000/catalogue/id/mpa-14446/ - provenance
http://127.0.0.1:8000/catalogue/id/swop-7960/ - creator, place_of_deposit, description
http://127.0.0.1:8000/catalogue/id/swop-1076/ - description

Search results:
Query on above id's


## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [x] Ensured that PR includes only commits relevant to the ticket
- [x] Waited for all CI jobs to pass before requesting a review
- [x] Added/updated tests and documentation where relevant

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
