### PR TITLE
HERITAGE-214 Add attributes to details page FE

### DIFF
--- a/etna/records/field_labels.py
+++ b/etna/records/field_labels.py
@@ -50,8 +50,8 @@ FIELD_LABELS = {
     "subjects": "Subject",
     "level": "Level",
     "type": "Type",
-    "identifier": "Identifier",
+    "identifier": "Reference",
     "provenance": "Provenance",
     "creator": "Creator",
-    "place_of_deposit": "Place of deposit",
+    "place_of_deposit": "Held by",
 }

--- a/etna/records/field_labels.py
+++ b/etna/records/field_labels.py
@@ -53,5 +53,5 @@ FIELD_LABELS = {
     "identifier": "Reference",
     "provenance": "Provenance",
     "creator": "Creator",
-    "repository": "Repository",
+    "repository": "Held by",
 }

--- a/templates/includes/records/record-details-community.html
+++ b/templates/includes/records/record-details-community.html
@@ -85,12 +85,11 @@
         <td>{{ record.provenance }}</td>
     </tr>
 {% endif %}
-{% if record.place_of_deposit %}
+{% if record.repository %}
     <tr>
-        <th scope="row">{{ 'place_of_deposit'|as_label }}</th>
+        <th scope="row">{{ 'repository'|as_label }}</th>
         <td>
-            {{ record.place_of_deposit.mediator }}
-            {{ record.place_of_deposit.repository }}
+            {{ record.repository }}
         </td>
     </tr>
 {% endif %}

--- a/templates/includes/records/record-details-community.html
+++ b/templates/includes/records/record-details-community.html
@@ -79,3 +79,24 @@
         <td>{{ record.type }}</td>
     </tr>
 {% endif %}
+{% if record.provenance %}
+    <tr>
+        <th scope="row">{{ 'provenance'|as_label }}</th>
+        <td>{{ record.provenance }}</td>
+    </tr>
+{% endif %}
+{% if record.place_of_deposit %}
+    <tr>
+        <th scope="row">{{ 'place_of_deposit'|as_label }}</th>
+        <td>
+            {{ record.place_of_deposit.mediator }}
+            {{ record.place_of_deposit.repository }}
+        </td>
+    </tr>
+{% endif %}
+{% if record.creator %}
+    <tr>
+        <th scope="row">{{ 'creator'|as_label }}</th>
+        <td>{{ record.creator }}</td>
+    </tr>
+{% endif %}


### PR DESCRIPTION
Ticket URL: [HERITAGE-214](https://national-archives.atlassian.net/browse/HERITAGE-214)

## About these changes

Add new table rows for additional attributes on details page

## How to check these changes

See table at `/catalogue/id/swop-33491/` - I've not been able to find any records containing provenance

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [x] Ensured that PR includes only commits relevant to the ticket
- [x] Waited for all CI jobs to pass before requesting a review
- [ ] Added/updated tests and documentation where relevant

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)


[HERITAGE-214]: https://national-archives.atlassian.net/browse/HERITAGE-214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ