### PR TITLE
FIX: Show record details, update description for tna/roa

### DIFF
--- a/etna/records/models.py
+++ b/etna/records/models.py
@@ -230,9 +230,7 @@ class Record(DataLayerMixin, APIModel):
             strip_html_value = strip_html(updated_value, allow_tags=allow_tags)
             return mark_safe(strip_html_value)
 
-        # TODO:Rosetta
-        # return mark_safe(raw)
-        return raw
+        return mark_safe(raw)
 
     @cached_property
     def listing_description(self) -> str:

--- a/etna/records/views/records.py
+++ b/etna/records/views/records.py
@@ -6,6 +6,7 @@ from django.template.response import TemplateResponse
 from django.urls import reverse
 from django.utils import timezone
 
+from ...ciim.constants import BucketKeys
 from ...ciim.exceptions import DoesNotExist
 from ...ciim.paginator import APIPaginator
 from ..api import records_client
@@ -97,6 +98,7 @@ def record_detail_view(request, id):
         back_to_search_url=back_to_search_url,
         page_type=page_type,
         page_title=page_title,
+        bucketkeys=BucketKeys,
     )
 
     # Note: This page uses cookies to render GTM, please ensure to keep TemplateResponse or similar when changed.

--- a/etna/search/views.py
+++ b/etna/search/views.py
@@ -659,7 +659,7 @@ class CatalogueSearchView(BucketsMixin, BaseFilteredSearchView):
     api_method_name = "search"
     # api_stream = Stream.EVIDENTIAL  # TODO: Keep, not in scope for Ohos-Etna at this time
     bucket_list = CATALOGUE_BUCKETS
-    default_group = BucketKeys.COMMUNITY
+    default_group = BucketKeys.COMMUNITY.value
     form_class = CatalogueSearchForm
     template_name = "search/catalogue_search.html"
     search_tab = SearchTabs.CATALOGUE.value
@@ -687,7 +687,7 @@ class CatalogueSearchView(BucketsMixin, BaseFilteredSearchView):
 class CatalogueSearchLongFilterView(BaseLongFilterOptionsView):
     api_method_name = "search"
     # api_stream = Stream.EVIDENTIAL  # TODO: Keep, not in scope for Ohos-Etna at this time
-    default_group = BucketKeys.COMMUNITY
+    default_group = BucketKeys.COMMUNITY.value
     form_class = CatalogueSearchForm
     template_name = "search/long_filter_options.html"
     page_type = "Catalogue search long filter page"

--- a/templates/records/record_detail.html
+++ b/templates/records/record_detail.html
@@ -24,7 +24,7 @@
             <div class="record-details">
                 <table class="record-details__table">
                     <tbody>
-                        {% if form.group.value == bucketkeys.COMMUNITY.value %}
+                        {% if record.group == bucketkeys.COMMUNITY.value %}
                             {% include "includes/records/record-details-community.html" %}
                         {% else %}
                             {% include "includes/records/record-details.html" %}
@@ -34,14 +34,14 @@
             </div>
         </div>
 
-        {% if form.group.value == bucketkeys.COMMUNITY.value and record.has_enrichment %}
+        {% if record.group == bucketkeys.COMMUNITY.value and record.has_enrichment %}
             <div class="tna-column tna-column--width-1-3 tna-column--width-1-3-medium tna-column--full-small tna-column--full-tiny">
                 {% include "includes/related-tags.html" %}
             </div>
         {% endif %}
     </div>
 
-    {% if form.group.value != bucketkeys.COMMUNITY.value %}
+    {% if record.group != bucketkeys.COMMUNITY.value %}
         <div class="tna-container">
             <div class="tna-column tna-column--full">
                 {% if record.hierarchy %}


### PR DESCRIPTION
Ticket URL: N/A

## About these changes

Issue: 
Record details for TNA/ROA is currently showing only the attributes applicable for community bucket.
The Description in details for TNA/ROA shows html markup.

Fix:
The fix is to show record details for TNA, ROA, and update description to remove html markup same as Etna.

## How to check these changes

http://127.0.0.1:8000/search/catalogue/?group=tna
http://127.0.0.1:8000/catalogue/id/N13807956/
http://127.0.0.1:8000/search/catalogue/?group=nonTna
http://127.0.0.1:8000/catalogue/id/C14667462/

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [x] Ensured that PR includes only commits relevant to the ticket
- [x] Waited for all CI jobs to pass before requesting a review
- [x] Added/updated tests and documentation where relevant

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
