### PR TITLE
HERITAGE-305 Wikidata overlays

### DIFF
--- a/sass/etna.scss
+++ b/sass/etna.scss
@@ -197,6 +197,7 @@ These are Etna specific components, created using BEM and following our guidelin
 @import "ohos/footer";
 @import "ohos/pagination";
 @import "ohos/tags";
+@import "ohos/wikidata-overlays";
 @import "ohos/checkbox";
 @import "ohos/search-results-map";
 @import "ohos/tag-frequency-chart";

--- a/sass/ohos/_tags.scss
+++ b/sass/ohos/_tags.scss
@@ -1,18 +1,6 @@
-.wikidata-overlay {
-    display: none;
-    position: absolute;
-    top: 100%;
-    left: 0;
-    right: 0;
-    z-index: 10;
-    border: 1px solid $color__black;
-    background-color: $color__grey-light;
-    padding: 20px;
-}
-
-
 .ohos-tag-container {
     position: relative;
+    display: inline-block;
 }
 
 .ohos-tag {
@@ -29,28 +17,30 @@
         text-decoration: none;
     }
 
+    background-color: var(--tag-theme-color);
+
     &--location {
-        background-color: #edae49;
+        --tag-theme-color: #edae49;
     }
 
     &--person {
-        background-color: #84a59d;
+        --tag-theme-color: #84a59d;
     }
 
     &--organisation {
-        background-color: #b5e2fa;
+        --tag-theme-color: #b5e2fa;
     }
 
     &--misc {
-        background-color: #f28482;
+        --tag-theme-color: #f28482;
     }
 
     &--other {
-        background-color: #faf0ca;
+        --tag-theme-color: #faf0ca;
     }
 
     &--clear {
-        background-color: $color--off-black;
+        --tag-theme-color: $color--off-black;
 
         &,
         &:link,
@@ -83,10 +73,6 @@
             text-decoration-thickness: inherit;
             background-color: $color__off-black;
             color: $color__grey-200;
-
-            + .wikidata-overlay:not(:empty) {
-                display: block;
-            }
         }
     }
 }

--- a/sass/ohos/_tags.scss
+++ b/sass/ohos/_tags.scss
@@ -1,3 +1,20 @@
+.wikidata-overlay {
+    display: none;
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    z-index: 10;
+    border: 1px solid $color__black;
+    background-color: $color__grey-light;
+    padding: 20px;
+}
+
+
+.ohos-tag-container {
+    position: relative;
+}
+
 .ohos-tag {
     display: inline-flex;
     border: 1px solid;
@@ -66,6 +83,10 @@
             text-decoration-thickness: inherit;
             background-color: $color__off-black;
             color: $color__grey-200;
+
+            + .wikidata-overlay:not(:empty) {
+                display: block;
+            }
         }
     }
 }

--- a/sass/ohos/_tags.scss
+++ b/sass/ohos/_tags.scss
@@ -17,7 +17,7 @@
         text-decoration: none;
     }
 
-    background-color: var(--tag-theme-color);
+    background-color: var(--tag-theme-color, $color__grey-500);
 
     &--location {
         --tag-theme-color: #edae49;

--- a/sass/ohos/_wikidata-overlays.scss
+++ b/sass/ohos/_wikidata-overlays.scss
@@ -1,0 +1,84 @@
+@use "@nationalarchives/frontend/nationalarchives/tools/typography";
+
+.wikidata {
+    --spacer-size: 1em;
+    display: none;
+    position: absolute;
+    top: calc(100% - 1px); // Accounts for border on hover target area
+    width: 300px;
+    right: 0;
+    z-index: 10;
+    background-color: $color__grey-light;
+    margin-top: var(--spacer-size);
+    box-shadow: 2px 2px 4px 0 rgb(0 0 0 / 25%);
+
+    &::before {
+        content: "";
+        height: var(--spacer-size);
+        display: block;
+        position: absolute;
+        bottom: 100%;
+        width: 100%;
+    }
+
+    &::after {
+        content: "";
+        height: 0;
+        width: 0;
+        right: 20px;
+        position: absolute;
+        bottom: 100%;
+        border: 12px solid transparent;
+        border-top: 0;
+        border-bottom-color: var(--tag-theme-color, $color__grey-500);
+    }
+
+    &__header {
+        display: flex;
+        align-items: flex-start;
+        gap: 1em;
+        padding: 1em;
+        background-color: var(--tag-theme-color, $color__grey-500);
+    }
+
+    &__header-meta {
+        margin: 0;
+        @include typography.relative-font-size(12);
+    }
+
+    &__content {
+        padding: 1em;
+    }
+
+    &__description {
+        margin-top: 0;
+    }
+
+    &__footer {
+        @include typography.relative-font-size(12);
+        display: flex;
+        align-items: center;
+        gap: 0.5em;
+        margin-top: 1em;
+
+        img {
+            margin: 0;
+        }
+    }
+
+    &__header-img {
+        background-color: rgb(0 0 0 / 10%);
+    }
+}
+
+.wikidata-container {
+    display: flex;
+
+    @media (hover: hover) {
+        &:hover {
+            .wikidata:not(:empty) {
+                display: block;
+            }
+        }
+    }
+}

--- a/sass/ohos/_wikidata-overlays.scss
+++ b/sass/ohos/_wikidata-overlays.scss
@@ -1,7 +1,7 @@
 @use "@nationalarchives/frontend/nationalarchives/tools/typography";
 
 .wikidata {
-    --spacer-size: 1em;
+    $spacer-size: 1em;
     display: none;
     position: absolute;
     top: calc(100% - 1px); // Accounts for border on hover target area
@@ -9,12 +9,12 @@
     right: 0;
     z-index: 10;
     background-color: $color__grey-light;
-    margin-top: var(--spacer-size);
+    margin-top: var($spacer-size);
     box-shadow: 2px 2px 4px 0 rgb(0 0 0 / 25%);
 
     &::before {
         content: "";
-        height: var(--spacer-size);
+        height: var($spacer-size);
         display: block;
         position: absolute;
         bottom: 100%;

--- a/sass/ohos/_wikidata-overlays.scss
+++ b/sass/ohos/_wikidata-overlays.scss
@@ -9,12 +9,12 @@
     right: 0;
     z-index: 10;
     background-color: $color__grey-light;
-    margin-top: var($spacer-size);
+    margin-top: $spacer-size;
     box-shadow: 2px 2px 4px 0 rgb(0 0 0 / 25%);
 
     &::before {
         content: "";
-        height: var($spacer-size);
+        height: $spacer-size;
         display: block;
         position: absolute;
         bottom: 100%;

--- a/scripts/src/modules/wikidata-overlays/wikidata-overlays.js
+++ b/scripts/src/modules/wikidata-overlays/wikidata-overlays.js
@@ -155,13 +155,16 @@ const addResultToFormattedData = (result) => {
 const init = async () => {
     const sparqlQuery = buildSparqlQuery(uniqueWikidataIds);
     const data = await executeSparqlQuery(sparqlQuery);
-    const results = data.results.bindings;
+    const results = data?.results?.bindings || [];
 
     results.forEach((result) => {
         addResultToFormattedData(result);
     });
 
-    createWikidataOverlays(formattedData);
+    if(Object.keys(formattedData).length > 0) {
+        createWikidataOverlays(formattedData);
+    }
+
 };
 
 init().catch((error) => console.error("init - Error fetching data:", error));

--- a/scripts/src/modules/wikidata-overlays/wikidata-overlays.js
+++ b/scripts/src/modules/wikidata-overlays/wikidata-overlays.js
@@ -161,10 +161,9 @@ const init = async () => {
         addResultToFormattedData(result);
     });
 
-    if(Object.keys(formattedData).length > 0) {
+    if (Object.keys(formattedData).length > 0) {
         createWikidataOverlays(formattedData);
     }
-
 };
 
 init().catch((error) => console.error("init - Error fetching data:", error));

--- a/scripts/src/modules/wikidata-overlays/wikidata-overlays.js
+++ b/scripts/src/modules/wikidata-overlays/wikidata-overlays.js
@@ -1,0 +1,86 @@
+const fetchData = async (url) => {
+  const response = await fetch(url);
+
+  if (!response.ok) {
+    throw new Error('Network response was not ok');
+  }
+
+  return response.json();
+}
+
+const fetchAllData = async (urls) => {
+  try {
+    const dataPromises = urls.map(url => fetchData(url));
+
+    const results = await Promise.all(dataPromises);
+
+    return results;
+
+  } catch (error) {
+    console.error('Error fetching data:', error);
+  }
+}
+
+const wikidataLinks = document.querySelectorAll('[data-js-wikidata-url]');
+
+const wikidataIds = [...wikidataLinks].map(link => link.getAttribute('data-js-wikidata-url').replace('https://www.wikidata.org/wiki/', ''));
+
+const wikidataUrls = wikidataIds.map(id => `https://www.wikidata.org/w/rest.php/wikibase/v0/entities/items/${id}`);
+
+const wikidata = await fetchAllData(wikidataUrls);
+
+const getEntryImage = (entry) => {
+  const imageName = entry?.statements?.P18?.[0]?.value?.content;
+
+  if (imageName) {
+    const image = encodeURI(`https://commons.wikimedia.org/w/index.php?title=Special:Redirect/file/${imageName}&width=74`);
+
+    return image;
+  }
+}
+
+const createTemplate = (data) => {
+  const template = document.createElement('template');
+  const image = getEntryImage(data);
+
+  const templateContainerClass = data.templateClass ? `${data.templateClass}` : '';
+  const labelTemplate = data.label ? `<p>${data.label}</p>` : '';
+  const imageTemplate = image ? `<img src="${image}" alt="">` : '';
+  const titleTemplate = data.labels.en ? `<h3>${data.labels.en}</h3>` : '';
+  const descriptionTemplate = data.descriptions.en ? `<p>${data.descriptions.en}</p>` : '';
+  const idTemplate = data.id ? `<p>${data.id}</p>` : '';
+
+  template.innerHTML = `
+    <div class="${templateContainerClass}">
+      ${labelTemplate}
+      ${imageTemplate}
+      ${titleTemplate}
+      ${descriptionTemplate}
+      ${idTemplate}
+    </div>
+  `;
+
+  return template;
+}
+
+wikidataLinks.forEach(link => {
+  const wikidataUrl = link.getAttribute('data-js-wikidata-url');
+  const id = wikidataUrl.replace('https://www.wikidata.org/wiki/', '');
+  const label = link.getAttribute('data-js-wikidata-tag-type-label');
+  const templateClass = link.getAttribute('data-js-wikidata-tag-type');
+
+  const data = {
+    label,
+    templateClass,
+    ...wikidata.find(entry => entry.id === id)
+  };
+
+  const template = createTemplate(data);
+
+  const overlayContainer = document.querySelector(`[data-js-wikidata-overlay="${wikidataUrl}"]`);
+
+  overlayContainer.appendChild(template.content);
+});
+
+// Ensures webpack will treat the file as a module and handle async/await correctly
+export {}

--- a/scripts/src/modules/wikidata-overlays/wikidata-overlays.js
+++ b/scripts/src/modules/wikidata-overlays/wikidata-overlays.js
@@ -1,86 +1,167 @@
+/**
+ * fetchData
+ *
+ * @param {String} url
+ * @returns {Promise<Object>}
+ *
+ * Fetch data from a given URL
+ */
 const fetchData = async (url) => {
-  const response = await fetch(url);
+    const response = await fetch(url);
 
-  if (!response.ok) {
-    throw new Error('Network response was not ok');
-  }
+    if (!response.ok) {
+        throw new Error("Network response was not ok");
+    }
 
-  return response.json();
-}
+    return response.json();
+};
 
-const fetchAllData = async (urls) => {
-  try {
-    const dataPromises = urls.map(url => fetchData(url));
+const createTemplate = (data, tagType) => {
+    const template = document.createElement("template");
 
-    const results = await Promise.all(dataPromises);
+    const tagTypeTemplate = tagType
+        ? `<p class="wikidata__description">${tagType}</p>`
+        : "";
+    const imageTemplate = data.imagePath
+        ? `<img src="${data.imagePath}" alt="" width="74" class="wikidata__header-img" loading="lazy">`
+        : "";
+    const countryTemplate = data.countryLabel
+        ? `<p class="wikidata__header-meta">${data.countryLabel}</p>`
+        : "";
+    const titleTemplate = data.label ? `<h3>${data.label}</h3>` : "";
+    const descriptionTemplate = data.description
+        ? `<p>${data.description}</p>`
+        : "";
+    const idTemplate = data.id ? `${data.id}` : "";
 
-    return results;
-
-  } catch (error) {
-    console.error('Error fetching data:', error);
-  }
-}
-
-const wikidataLinks = document.querySelectorAll('[data-js-wikidata-url]');
-
-const wikidataIds = [...wikidataLinks].map(link => link.getAttribute('data-js-wikidata-url').replace('https://www.wikidata.org/wiki/', ''));
-
-const wikidataUrls = wikidataIds.map(id => `https://www.wikidata.org/w/rest.php/wikibase/v0/entities/items/${id}`);
-
-const wikidata = await fetchAllData(wikidataUrls);
-
-const getEntryImage = (entry) => {
-  const imageName = entry?.statements?.P18?.[0]?.value?.content;
-
-  if (imageName) {
-    const image = encodeURI(`https://commons.wikimedia.org/w/index.php?title=Special:Redirect/file/${imageName}&width=74`);
-
-    return image;
-  }
-}
-
-const createTemplate = (data) => {
-  const template = document.createElement('template');
-  const image = getEntryImage(data);
-
-  const templateContainerClass = data.templateClass ? `${data.templateClass}` : '';
-  const labelTemplate = data.label ? `<p>${data.label}</p>` : '';
-  const imageTemplate = image ? `<img src="${image}" alt="">` : '';
-  const titleTemplate = data.labels.en ? `<h3>${data.labels.en}</h3>` : '';
-  const descriptionTemplate = data.descriptions.en ? `<p>${data.descriptions.en}</p>` : '';
-  const idTemplate = data.id ? `<p>${data.id}</p>` : '';
-
-  template.innerHTML = `
-    <div class="${templateContainerClass}">
-      ${labelTemplate}
+    template.innerHTML = `
+    <div class="wikidata__header">
       ${imageTemplate}
-      ${titleTemplate}
+
+      <div>
+        ${tagTypeTemplate}
+        ${titleTemplate}
+        ${countryTemplate}
+      </div>
+    </div>
+
+    <div class="wikidata__content">
       ${descriptionTemplate}
-      ${idTemplate}
+
+      <div class="wikidata__footer">
+        <img src="/static/images/wikidata-logo.png" width="34" height="25" alt="Wikidata logo">
+        ${idTemplate}
+      </div>
     </div>
   `;
 
-  return template;
-}
+    return template;
+};
 
-wikidataLinks.forEach(link => {
-  const wikidataUrl = link.getAttribute('data-js-wikidata-url');
-  const id = wikidataUrl.replace('https://www.wikidata.org/wiki/', '');
-  const label = link.getAttribute('data-js-wikidata-tag-type-label');
-  const templateClass = link.getAttribute('data-js-wikidata-tag-type');
+/**
+ * createWikidataOverlays
+ *
+ * @param {Object} data
+ */
+const createWikidataOverlays = (data) => {
+    Object.entries(data).forEach(([id, item]) => {
+        // Multiple tags can have the same wikidata entry
+        const overlayContainers = document.querySelectorAll(
+            `[data-js-wikidata-overlay="https://www.wikidata.org/wiki/${id}"]`,
+        );
 
-  const data = {
-    label,
-    templateClass,
-    ...wikidata.find(entry => entry.id === id)
-  };
+        overlayContainers.forEach((overlayContainer) => {
+            const tagType = overlayContainer.getAttribute(
+                "data-js-wikidata-tag-type-label",
+            );
 
-  const template = createTemplate(data);
+            const template = createTemplate(item, tagType);
+            overlayContainer.appendChild(template.content);
+        });
+    });
+};
 
-  const overlayContainer = document.querySelector(`[data-js-wikidata-overlay="${wikidataUrl}"]`);
+const wikidataLinks = document.querySelectorAll("[data-js-wikidata-url]");
+const wikidataIds = [...wikidataLinks].map((link) =>
+    link.getAttribute("data-js-wikidata-url").split("/").pop(),
+);
 
-  overlayContainer.appendChild(template.content);
-});
+/**
+ * Multiple tags can have the same wikidata entry so we remove them before building the API query
+ */
+const uniqueWikidataIds = [...new Set(wikidataIds)];
 
-// Ensures webpack will treat the file as a module and handle async/await correctly
-export {}
+/**
+ * buildSparqlQuery
+ *
+ * Build query using SPARQL to fetch data from Wikidata
+ * {@link https://www.wikidata.org/wiki/Wikidata:SPARQL_tutorial}
+ *
+ * To assist building the query it's possible to get entity data from the rest API
+ * {@link https://www.wikidata.org/w/rest.php/wikibase/v0/entities/items/[entityId]}
+ *
+ * It's also possible to browse properties by ID
+ * {@link https://hay.toolforge.org/propbrowse/}
+ *
+ * @param {Array} ids
+ * @returns {String}
+ */
+const buildSparqlQuery = (ids) => `
+  # Properties that will be returned by the API
+  SELECT ?item ?label ?description ?image ?countryLabel
+  WHERE {
+    VALUES ?item { ${ids.map((id) => `wd:${id}`).join(" ")} }
+
+    # Specific fields for each item
+    ?item rdfs:label ?label .
+    ?item schema:description ?description .
+    FILTER(LANG(?label) = "en")
+    FILTER(LANG(?description) = "en")
+
+    OPTIONAL { ?item wdt:P18 ?image . }
+
+    OPTIONAL {
+      ?item wdt:P17 ?country .
+      ?country rdfs:label ?countryLabel .
+      FILTER(LANG(?countryLabel) = "en")
+    }
+  }
+`;
+
+const executeSparqlQuery = async (query) => {
+    const url = `https://query.wikidata.org/sparql?query=${encodeURIComponent(query)}&format=json`;
+    const data = await fetchData(url);
+    return data;
+};
+
+const formattedData = {};
+
+const addResultToFormattedData = (result) => {
+    const id = result.item.value.split("/").pop();
+
+    if (!formattedData[id]) {
+        formattedData[id] = {
+            id,
+            label: result.label.value,
+            countryLabel: result?.countryLabel?.value,
+            description: result.description.value,
+            imagePath: result?.image?.value
+                ? `${result.image.value}?width=74`
+                : "",
+        };
+    }
+};
+
+const init = async () => {
+    const sparqlQuery = buildSparqlQuery(uniqueWikidataIds);
+    const data = await executeSparqlQuery(sparqlQuery);
+    const results = data.results.bindings;
+
+    results.forEach((result) => {
+        addResultToFormattedData(result);
+    });
+
+    createWikidataOverlays(formattedData);
+};
+
+init().catch((error) => console.error("init - Error fetching data:", error));

--- a/templates/includes/tags-wiki.html
+++ b/templates/includes/tags-wiki.html
@@ -6,19 +6,25 @@
 
     {% for item in tag|slice:":5" %}
         <dd>
-            <span class="ohos-tag ohos-tag--{{ css_extn_style }}">
-                <span class="ohos-tag__inner">{{ item.value }}</span>
-                {% if item.url %}
-                    <a href="{{ item.url }}" target="_blank" class="ohos-tag__link" data-js-wikidata-url="{{ item.url }}" data-js-wikidata-tag-type="{{ css_extn_style }}" data-js-wikidata-tag-type-label="{{ label }}">
-                        Wikidata
-                        <i aria-hidden="true" class="ohos-tag__link-icon fa-solid fa-external-link"></i>
-                    </a>
-                {% endif %}
-            </span>
+            <div class="ohos-tag-container">
+                <span class="ohos-tag ohos-tag--{{ css_extn_style }}">
+                    <span class="ohos-tag__inner">{{ item.value }}</span>
+                    {% if item.url %}
+                        <a href="{{ item.url }}" target="_blank" class="ohos-tag__link" data-js-wikidata-url="{{ item.url }}" data-js-wikidata-tag-type="{{ css_extn_style }}" data-js-wikidata-tag-type-label="{{ label }}">
+                            Wikidata
+                            <i aria-hidden="true" class="ohos-tag__link-icon fa-solid fa-external-link"></i>
+                        </a>
 
-            {% if item.url %}
-                <div class="" data-js-wikidata-overlay="{{ item.url }}"></div>
-            {% endif %}
+                        <div class="wikidata-overlay" data-js-wikidata-overlay="{{ item.url }}"></div>
+                    {% endif %}
+                </span>
+
+                {% comment %}
+                {% if item.url %}
+                    <div class="wikidata-overlay" data-js-wikidata-overlay="{{ item.url }}"></div>
+                {% endif %}
+                {% endcomment %}
+            </div>
         </dd>
     {% endfor %}
 {% endif %}

--- a/templates/includes/tags-wiki.html
+++ b/templates/includes/tags-wiki.html
@@ -9,12 +9,16 @@
             <span class="ohos-tag ohos-tag--{{ css_extn_style }}">
                 <span class="ohos-tag__inner">{{ item.value }}</span>
                 {% if item.url %}
-                    <a href="{{ item.url }}" target="_blank" class="ohos-tag__link">
+                    <a href="{{ item.url }}" target="_blank" class="ohos-tag__link" data-js-wikidata-url="{{ item.url }}" data-js-wikidata-tag-type="{{ css_extn_style }}" data-js-wikidata-tag-type-label="{{ label }}">
                         Wikidata
                         <i aria-hidden="true" class="ohos-tag__link-icon fa-solid fa-external-link"></i>
                     </a>
                 {% endif %}
             </span>
+
+            {% if item.url %}
+                <div class="" data-js-wikidata-overlay="{{ item.url }}"></div>
+            {% endif %}
         </dd>
     {% endfor %}
 {% endif %}

--- a/templates/includes/tags-wiki.html
+++ b/templates/includes/tags-wiki.html
@@ -7,23 +7,19 @@
     {% for item in tag|slice:":5" %}
         <dd>
             <div class="ohos-tag-container">
-                <span class="ohos-tag ohos-tag--{{ css_extn_style }}">
-                    <span class="ohos-tag__inner">{{ item.value }}</span>
+                <div class="ohos-tag ohos-tag--{{ css_extn_style }}">
+                    <div class="ohos-tag__inner">{{ item.value }}</div>
                     {% if item.url %}
-                        <a href="{{ item.url }}" target="_blank" class="ohos-tag__link" data-js-wikidata-url="{{ item.url }}" data-js-wikidata-tag-type="{{ css_extn_style }}" data-js-wikidata-tag-type-label="{{ label }}">
-                            Wikidata
-                            <i aria-hidden="true" class="ohos-tag__link-icon fa-solid fa-external-link"></i>
-                        </a>
+                        <div class="wikidata-container">
+                            <a href="{{ item.url }}" target="_blank" class="ohos-tag__link" data-js-wikidata-url="{{ item.url }}">
+                                Wikidata
+                                <i aria-hidden="true" class="ohos-tag__link-icon fa-solid fa-external-link"></i>
+                            </a>
 
-                        <div class="wikidata-overlay" data-js-wikidata-overlay="{{ item.url }}"></div>
+                            <div class="wikidata" data-js-wikidata-overlay="{{ item.url }}" data-js-wikidata-tag-type-label="{{ label }}"></div>
+                        </div>
                     {% endif %}
-                </span>
-
-                {% comment %}
-                {% if item.url %}
-                    <div class="wikidata-overlay" data-js-wikidata-overlay="{{ item.url }}"></div>
-                {% endif %}
-                {% endcomment %}
+                </div>
             </div>
         </dd>
     {% endfor %}

--- a/templates/records/record_detail.html
+++ b/templates/records/record_detail.html
@@ -58,4 +58,5 @@
 
 {% block extra_js %}
     <script src="{% static 'scripts/details.js' %}"></script>
+    <script src="{% static 'scripts/wikidata_overlays.js' %}"></script>
 {% endblock %}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,6 +23,7 @@ module.exports = {
         whats_on: "./scripts/src/whats-on.js",
         search_results_map: "./scripts/src/search-results-map.js",
         tag_frequency_chart: "./scripts/src/modules/tag-frequency/tag-frequency-chart.js",
+        wikidata_overlays: "./scripts/src/modules/wikidata-overlays/wikidata-overlays.js",
     },
     output: {
         filename: "[name].js",


### PR DESCRIPTION
Ticket URL: [HERITAGE-305](https://national-archives.atlassian.net/browse/HERITAGE-305)

## About these changes

Add wikidata overlays to detail pages where wikidata is available on each tag. Uses SPARQL rather than the rest API to reduce the request into a single, tiny response

## How to check these changes

A page containing wikidata overlays can be found at `/catalogue/id/swop-15407/`

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [x] Ensured that PR includes only commits relevant to the ticket
- [x] Waited for all CI jobs to pass before requesting a review
- [ ] Added/updated tests and documentation where relevant

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)


[HERITAGE-305]: https://national-archives.atlassian.net/browse/HERITAGE-305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ