### PR TITLE
HERITAGE-291: Nested Checkbox filters - BE

### DIFF
--- a/etna/ciim/client.py
+++ b/etna/ciim/client.py
@@ -32,7 +32,7 @@ from .exceptions import (
     DoesNotExist,
     MultipleObjectsReturned,
 )
-from .utils import prepare_filter_aggregations
+from .utils import prepare_filter_aggregations, prepare_ohos_params
 
 logger = logging.getLogger(__name__)
 
@@ -226,8 +226,8 @@ class ClientAPI:
         covering_date_from: Optional[Union[date, datetime]] = None,
         covering_date_to: Optional[Union[date, datetime]] = None,
         # stream: Optional[Stream] = None,   # TODO: Keep, not in scope for Ohos-Etna at this time
-        aggregations: Optional[list[Aggregation]] = None,
-        filter_aggregations: Optional[list[str]] = None,
+        aggregations: Optional[List[Aggregation]] = None,
+        filter_aggregations: Optional[List[str]] = None,
         # filter_keyword: Optional[str] = None,   # TODO: Keep, not in scope for Ohos-Etna at this time
         sort: Optional[Sort] = None,
         offset: Optional[int] = None,
@@ -257,6 +257,17 @@ class ClientAPI:
         size:
             Number of results to return
         """
+        if not aggregations:
+            aggregations = []
+
+        if not filter_aggregations:
+            filter_aggregations = []
+
+        if group == BucketKeys.COMMUNITY:
+            aggregations, filter_aggregations = prepare_ohos_params(
+                aggregations, filter_aggregations
+            )
+
         params = {
             "q": q,
             # "fields": f"stream:{stream}",  # TODO: Keep, not in scope for Ohos-Etna at this time

--- a/etna/ciim/constants.py
+++ b/etna/ciim/constants.py
@@ -43,6 +43,7 @@ class Aggregation(StrEnum):
     TYPE = "type"
     COUNTRY = "country"
     LOCATION = "location"
+    COMMUNITY = "community"
 
 
 DEFAULT_AGGREGATIONS = [
@@ -122,7 +123,7 @@ CATALOGUE_BUCKETS = BucketList(
             description="Results for records held at The National Archives that match your search term.",
             # TODO: Keep, not in scope for Ohos-Etna at this time
             # aggregations=DEFAULT_AGGREGATIONS + [Aggregation.COLLECTION],
-            aggregations=[Aggregation.COLLECTION],
+            aggregations=[Aggregation.COMMUNITY],
         ),
         Bucket(
             key=BucketKeys.TNA,
@@ -711,3 +712,46 @@ CLOSURE_CLOSED_STATUS = [
     "Closed Or Retained Document, Closed Description",
     "Closed Or Retained Document, Open Description",
 ]
+
+
+# Checkbox attr
+COLLECTION_ATTR_FOR_ALL_BUCKETS = "collection"
+# GROUP_CHECKBOX_NAME_MAP = {BucketKeys.COMMUNITY:{COLLECTION_ATTR_FOR_ALL_BUCKETS: "community"}}
+# maps name of form checkbox attr with api aggregations name {<form attr>:<api aggregations name>}
+OHOS_CHECKBOX_AGGS_NAME_MAP = {COLLECTION_ATTR_FOR_ALL_BUCKETS: "community"}
+# maps name of form checkbox attr which is also filter attr with value to replace
+OHOS_FILTER_AGGS_NAME_MAP = {COLLECTION_ATTR_FOR_ALL_BUCKETS: "collectionOhos"}
+
+"""
+CONFIG:
+Nested/Hierarchy checkboxes
+Nesting of one level i.e. "parent" -> "child/children", others are "orphan"
+collections are checkboxes on the form. 
+Nested collections - collections within a collection
+
+{checkbox value:aggregations} 
+checkbox value - name of the collection
+aggregations - name of the aggregations configured in CIMM for that "value"
+"""
+NESTED_CHECKBOX_VALUES_AGGS_NAMES = {
+    "Surrey History Centre": "collectionSurrey",
+    "Morrab Photo Archive": "collectionMorrab",
+}
+
+PARENT_AGGS_ALIAS_PREFIX = "parent-"
+CHILD_AGGS_ALIAS_PREFIX = "child-"
+NESTED_CHILDREN_KEY = "children"
+AGGS_LOOKUP_KEY = "key"
+
+PARENT_AGGS = [
+    PARENT_AGGS_ALIAS_PREFIX + item
+    for item in NESTED_CHECKBOX_VALUES_AGGS_NAMES.values()
+]
+
+NESTED_PREFIX_AGGS_PAIRS = {}
+for aggs in NESTED_CHECKBOX_VALUES_AGGS_NAMES.values():
+    NESTED_PREFIX_AGGS_PAIRS.update(
+        {PARENT_AGGS_ALIAS_PREFIX + aggs: CHILD_AGGS_ALIAS_PREFIX + aggs}
+    )
+
+NESTED_SEE_MORE_LABEL = "See more collections"

--- a/etna/ciim/constants.py
+++ b/etna/ciim/constants.py
@@ -726,10 +726,10 @@ OHOS_FILTER_AGGS_NAME_MAP = {COLLECTION_ATTR_FOR_ALL_BUCKETS: "collectionOhos"}
 CONFIG:
 Nested/Hierarchy checkboxes
 Nesting of one level i.e. "parent" -> "child/children", others are "orphan"
-collections are checkboxes on the form. 
+collections are checkboxes on the form.
 Nested collections - collections within a collection
 
-{checkbox value:aggregations} 
+{checkbox value:aggregations}
 checkbox value - name of the collection
 aggregations - name of the aggregations configured in CIMM for that "value"
 """

--- a/etna/ciim/tests/factories.py
+++ b/etna/ciim/tests/factories.py
@@ -107,13 +107,22 @@ def create_response(record={}, status_code=None):
     }
 
 
-def create_search_response(records=[], aggregations=[], total_count=None):
+def create_search_response(
+    records=None, aggregations=None, buckets=None, total_count=None
+):
+    if not records:
+        records = []
+    if not aggregations:
+        aggregations = []
+    if not buckets:
+        buckets = []
     if not total_count:
         total_count = len(records)
 
     return {
         "data": records,
         "aggregations": aggregations,
+        "buckets": buckets,
         "stats": {
             "total": total_count,
         },

--- a/etna/ciim/tests/test_utils.py
+++ b/etna/ciim/tests/test_utils.py
@@ -10,6 +10,7 @@ from ..utils import (
     find_all,
     format_description_markup,
     pluck,
+    prepare_ohos_params,
     strip_html,
 )
 
@@ -413,3 +414,96 @@ class TestStripHtml(SimpleTestCase):
         allow_tags = {"a", "br", "p"}
         result = strip_html(value, allow_tags=allow_tags)
         self.assertEqual(result, expected)
+
+
+class TestPrepareOhosParam(SimpleTestCase):
+
+    def test_prepare_ohos_param(self):
+
+        test_data = (
+            (
+                "orphan selection",
+                (
+                    ["community"],
+                    ["collection:Sharing Wycombe's Old Photographs", "group:community"],
+                ),
+                (
+                    ["community"],
+                    [
+                        "collectionOhos:Sharing Wycombe's Old Photographs",
+                        "group:community",
+                    ],
+                ),
+            ),
+            (
+                "parent selection",
+                (
+                    ["community"],
+                    [
+                        "collection:parent-collectionSurrey:Surrey History Centre",
+                        "collection:parent-collectionMorrab:Morrab Photo Archive",
+                        "group:community",
+                    ],
+                ),
+                (
+                    ["community", "collectionSurrey", "collectionMorrab"],
+                    [
+                        "collectionOhos:Surrey History Centre",
+                        "collectionOhos:Morrab Photo Archive",
+                        "group:community",
+                    ],
+                ),
+            ),
+            (
+                "parent children selection",
+                (
+                    ["community"],
+                    [
+                        "collection:parent-collectionSurrey:Surrey History Centre",
+                        "collection:child-collectionSurrey:GYPSY ROMA TRAVELLER HISTORY MONTH: RECORDED INTERVIEWS",
+                        "collection:child-collectionSurrey:LINGFIELD ORAL HISTORY PROJECT: TRANSCRIPTS",
+                        "collection:parent-collectionMorrab:Morrab Photo Archive",
+                        "collection:child-collectionMorrab:Miscellaneous Photos",
+                        "group:community",
+                    ],
+                ),
+                (
+                    ["community", "collectionSurrey", "collectionMorrab"],
+                    [
+                        "collectionOhos:GYPSY ROMA TRAVELLER HISTORY MONTH: RECORDED INTERVIEWS",
+                        "collectionOhos:LINGFIELD ORAL HISTORY PROJECT: TRANSCRIPTS",
+                        "collectionOhos:Miscellaneous Photos",
+                        "group:community",
+                    ],
+                ),
+            ),
+            (
+                "children selection",
+                (
+                    ["community"],
+                    [
+                        "collection:child-collectionSurrey:GYPSY ROMA TRAVELLER HISTORY MONTH: RECORDED INTERVIEWS",
+                        "collection:child-collectionSurrey:LINGFIELD ORAL HISTORY PROJECT: TRANSCRIPTS",
+                        "collection:child-collectionMorrab:Miscellaneous Photos",
+                        "group:community",
+                    ],
+                ),
+                (
+                    ["community", "collectionSurrey", "collectionMorrab"],
+                    [
+                        "collectionOhos:GYPSY ROMA TRAVELLER HISTORY MONTH: RECORDED INTERVIEWS",
+                        "collectionOhos:LINGFIELD ORAL HISTORY PROJECT: TRANSCRIPTS",
+                        "collectionOhos:Miscellaneous Photos",
+                        "group:community",
+                    ],
+                ),
+            ),
+        )
+
+        for label, value, expected in test_data:
+            with self.subTest(label):
+                aggs, filter = prepare_ohos_params(*value)
+                aggs_equality = set(aggs).issubset(set(expected[0]))
+                filter_equality = set(filter).issubset(set(expected[1]))
+                self.assertTrue(aggs_equality)
+                self.assertTrue(filter_equality)

--- a/etna/records/models.py
+++ b/etna/records/models.py
@@ -16,7 +16,7 @@ from django.utils.safestring import mark_safe
 from pyquery import PyQuery as pq
 
 from ..analytics.mixins import DataLayerMixin
-from ..ciim.constants import BucketKeys, TagTypes
+from ..ciim.constants import CATALOGUE_BUCKETS, BucketKeys, TagTypes
 from ..ciim.models import APIModel
 from ..ciim.utils import (
     NOT_PROVIDED,
@@ -629,7 +629,19 @@ class Record(DataLayerMixin, APIModel):
 
     @cached_property
     def group(self) -> str:
-        return self.template.get("group", "")
+        group = self.template.get("group", "")
+
+        ohos_buckets_keys = [item.key for item in CATALOGUE_BUCKETS]
+
+        if group not in ohos_buckets_keys:
+            # group_array-some records have many groups attached to them
+            # indentifies the one the belongs to OHOS buckets if not found in "group" attr
+            if group_array := self.template.get("groupArray", ""):
+                groups = [item.get("value", "") for item in group_array]
+                for item in groups:
+                    if item in ohos_buckets_keys:
+                        group = item
+        return group
 
     @cached_property
     def collection(self) -> str:

--- a/etna/search/templates/search/widgets/search-filter-checkbox-list.html
+++ b/etna/search/templates/search/widgets/search-filter-checkbox-list.html
@@ -3,9 +3,34 @@
         <ul class="search-filters__widget-list">
             {% for group, options, index in widget.optgroups %}
                 {% for option in options %}
-                    <li class="search-filters__widget-list-item ohos-checkbox-container">
-                        {% include option.template_name with widget=option %}
-                    </li>
+                    {% if group %}
+                        {# write nested level checkbox of 1 level of hierarchy parent-child #}
+                        {% if option.value != "See more collections" %}
+                            {# skip see more checkbox value #}
+                            {% if forloop.first %}
+                                <li class="search-filters__widget-list-item ohos-checkbox-container">
+                                    {% include option.template_name with widget=option %}
+                                    <ul>
+                            {% else %}
+                                <li class="search-filters__widget-list-item ohos-checkbox-container">
+                                    {% include option.template_name with widget=option %}
+                                </li>
+                            {% endif %}
+                        {% endif %}
+                        {% if forloop.last %}
+                                </ul>
+                            </li>
+                        {% endif %}
+                        {% if option.value == "See more collections" %}
+                            {# see more checkbox value as link #}
+                            <a href="" aria-label='See more'>{{ option.label }}</a>
+                        {% endif %}
+                    {% else %}
+                        {# write orphan or no level or no hierarchy checkbox #}
+                        <li class="search-filters__widget-list-item ohos-checkbox-container">
+                            {% include option.template_name with widget=option %}
+                        </li>
+                    {% endif %}
                 {% endfor %}
             {% endfor %}
         </ul>

--- a/etna/search/tests/test_views.py
+++ b/etna/search/tests/test_views.py
@@ -227,7 +227,7 @@ class CatalogueSearchAPIIntegrationTest(SearchViewTestCase):
             responses.calls[0].request.url,
             (
                 f"{settings.CLIENT_BASE_URL}/search"
-                "?aggs=collection"
+                "?aggs=community"
                 "&filter=group%3Acommunity"
                 "&sort="
                 "&from=0"


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/HERITAGE-291

## About these changes

- handle `group` values from `groupArray` for buckets
- updated label for OHOS collections
- modified api response to prepare for nested choices
- modified dynamic checkbox to handle nested values
- modified checkbox html structure to handle nested values
- modified choice data to handle nested values
- modified api calls to CIIM for nested filter checkboxes
- modified filter labels to handle "parent" checkboxes
- add/update tests
- sorting of collections for tna,roa are removed.
- Prefixed Aggregate alias names are added to the value in the URL for a nested collections `parent-collectionMorrab`, `child-collectionSurrey`
- The collection field is same for all buckets. For OHOS the "collection" maps to "community" aggregate is handled in the application.
- Any new collections for OHOS that are configured in CIIM must also be configured in this APP - `NESTED_CHECKBOX_VALUES_AGGS_NAMES`

## How to check these changes

http://127.0.0.1:8000/search/catalogue/?group=community
- review archives that have nested collections
- review checkbox label

Select multiple "parent" with "orphan"
http://127.0.0.1:8000/search/catalogue/?covering_date_from_0=&covering_date_from_1=&covering_date_from_2=&covering_date_to_0=&covering_date_to_1=&covering_date_to_2=&collection=Sharing+Wycombe%27s+Old+Photographs&collection=parent-collectionMorrab%3AMorrab+Photo+Archive&collection=parent-collectionSurrey%3ASurrey+History+Centre&q=&sort=&vis_view=list&group=community
- review nested collections
- review see more label+count
- review selected filters labels
- review results

Select all "parent" and "children" checkboxes
http://127.0.0.1:8000/search/catalogue/?covering_date_from_0=&covering_date_from_1=&covering_date_from_2=2007&covering_date_to_0=&covering_date_to_1=&covering_date_to_2=2010&collection=parent-collectionSurrey%3ASurrey+History+Centre&collection=child-collectionSurrey%3AGYPSY+ROMA+TRAVELLER+HISTORY+MONTH%3A+RECORDED+INTERVIEWS&collection=child-collectionSurrey%3ALINGFIELD+ORAL+HISTORY+PROJECT%3A+TRANSCRIPTS&q=&sort=&vis_view=list&group=community
- review filter labels
- collapse the "parent" filter label in one instance
- collapse the "child" filter label in another instance


## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [x] Ensured that PR includes only commits relevant to the ticket
- [x] Waited for all CI jobs to pass before requesting a review
- [x] Added/updated tests and documentation where relevant

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
