### PR TITLE
Feature/heritage 291 be show all chidren

### DIFF
--- a/etna/ciim/tests/test_utils.py
+++ b/etna/ciim/tests/test_utils.py
@@ -470,6 +470,8 @@ class TestPrepareOhosParam(SimpleTestCase):
                 (
                     ["community", "collectionSurrey", "collectionMorrab"],
                     [
+                        "collectionOhos:Surrey History Centre",
+                        "collectionOhos:Morrab Photo Archive",
                         "collectionOhos:GYPSY ROMA TRAVELLER HISTORY MONTH: RECORDED INTERVIEWS",
                         "collectionOhos:LINGFIELD ORAL HISTORY PROJECT: TRANSCRIPTS",
                         "collectionOhos:Miscellaneous Photos",

--- a/etna/ciim/utils.py
+++ b/etna/ciim/utils.py
@@ -366,7 +366,6 @@ def prepare_ohos_params(
     prepares params for ciim api
     - renames form filter to comply with Ohos
     - adds aggregations for nested filters
-    - remove parent filter if a child fiter is selected
 
     Ex:
     aggregations names:
@@ -406,13 +405,8 @@ def prepare_ohos_params(
     # add nested aggregations
     new_aggregations.extend(nested_aggs_to_add)
 
-    # remove parent filter if a child fiter is selected
     for parent, child in NESTED_PREFIX_AGGS_PAIRS.items():
-        if {parent, child}.issubset(selected_nested_prefix_aggs):
-            for index, item in enumerate(new_filter_aggregations):
-                if parent in item:
-                    new_filter_aggregations.pop(index)
-
+        # remove prefix aggs
         for index, agg in enumerate(new_filter_aggregations):
             new_filter_aggregations[index] = agg.replace(parent + ":", "").replace(
                 child + ":", ""

--- a/etna/search/views.py
+++ b/etna/search/views.py
@@ -19,6 +19,7 @@ from ..ciim.client import Aggregation, Sort
 from ..ciim.constants import (
     AGGS_LOOKUP_KEY,
     CATALOGUE_BUCKETS,
+    CHILD_AGGS_ALIAS_PREFIX,
     CLOSURE_CLOSED_STATUS,
     COLLECTION_ATTR_FOR_ALL_BUCKETS,
     NESTED_CHECKBOX_VALUES_AGGS_NAMES,
@@ -663,7 +664,7 @@ class BaseFilteredSearchView(BaseSearchView):
                     PARENT_AGGS_ALIAS_PREFIX + item
                     for item in NESTED_CHECKBOX_VALUES_AGGS_NAMES.values()
                 ] + [
-                    "child-" + item
+                    CHILD_AGGS_ALIAS_PREFIX + item
                     for item in NESTED_CHECKBOX_VALUES_AGGS_NAMES.values()
                 ]
 


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/HERITAGE-291

## About these changes

Shows all "children" collections irrespective of "children" selected for that "parent" collection

## How to check these changes

1 Parent with 4 children collections - where 1 child collection is selected
http://127.0.0.1:8000/search/catalogue/?covering_date_from_0=&covering_date_from_1=&covering_date_from_2=2010&covering_date_to_0=&covering_date_to_1=&covering_date_to_2=2020&collection=parent-collectionMorrab%3AMorrab+Photo+Archive&collection=child-collectionMorrab%3AContemporary&q=&sort=&vis_view=list&group=community

Shows all children collection with selected "child" collection and "parent" collection.

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [x] Ensured that PR includes only commits relevant to the ticket
- [x] Waited for all CI jobs to pass before requesting a review
- [x] Added/updated tests and documentation where relevant

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
