### PR TITLE
HERITAGE-328:Added search term param to Visualisation links

### DIFF
--- a/etna/search/common.py
+++ b/etna/search/common.py
@@ -4,6 +4,7 @@ from django.utils.http import urlencode
 from etna.ciim.constants import BucketKeys, TimelineTypes, VisViews
 
 # visualisation urls
+# contains ? param, so that more params can be appended with &
 VIS_URLS = {
     VisViews.LIST.value: f'{reverse("search-catalogue")}?{urlencode({"group": BucketKeys.COMMUNITY, "vis_view": VisViews.LIST})}',
     VisViews.MAP.value: f'{reverse("search-catalogue")}?{urlencode({"group": BucketKeys.COMMUNITY, "vis_view": VisViews.MAP})}',

--- a/etna/search/views.py
+++ b/etna/search/views.py
@@ -790,6 +790,9 @@ class CatalogueSearchView(BucketsMixin, BaseFilteredSearchView):
     def get_context_data(self, **kwargs: Any) -> Dict[str, Any]:
         self.set_session_info()
         module = importlib.import_module("etna.search.common")
+        q_search_param = ""
+        if q_search_term := self.form.cleaned_data.get("q"):
+            q_search_param = "&q=" + q_search_term
 
         kwargs.update(
             default_geo_data={
@@ -797,10 +800,11 @@ class CatalogueSearchView(BucketsMixin, BaseFilteredSearchView):
                 "lon": settings.FEATURE_GEO_LON,
                 "zoom": settings.FEATURE_GEO_ZOOM,
             },
-            list_view_url=module.VIS_URLS.get(VisViews.LIST.value),
-            map_view_url=module.VIS_URLS.get(VisViews.MAP.value),
-            timeline_view_url=module.VIS_URLS.get(VisViews.TIMELINE.value),
-            tag_view_url=module.VIS_URLS.get(VisViews.TAG.value),
+            list_view_url=module.VIS_URLS.get(VisViews.LIST.value) + q_search_param,
+            map_view_url=module.VIS_URLS.get(VisViews.MAP.value) + q_search_param,
+            timeline_view_url=module.VIS_URLS.get(VisViews.TIMELINE.value)
+            + q_search_param,
+            tag_view_url=module.VIS_URLS.get(VisViews.TAG.value) + q_search_param,
         )
         return super().get_context_data(**kwargs)
 


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/HERITAGE-328

## About these changes

Added search term param to Visualisation links

## How to check these changes

Search term = ufo
http://127.0.0.1:8000/search/catalogue/?q=ufo&group=community
List view, Map view, Timeline view and Tag view should contain &q=ufo appended to the link
Click the Visualisation link, the results are updated based on search term

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [x] Ensured that PR includes only commits relevant to the ticket
- [x] Waited for all CI jobs to pass before requesting a review
- [x] Added/updated tests and documentation where relevant

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
