### PR TITLE
HERITAGE-328: update visualisation view links to include filters

### DIFF
--- a/etna/ciim/tests/test_utils.py
+++ b/etna/ciim/tests/test_utils.py
@@ -424,6 +424,7 @@ class TestPrepareOhosParam(SimpleTestCase):
             (
                 "orphan selection",
                 (
+                    "list",
                     ["community"],
                     ["collection:Sharing Wycombe's Old Photographs", "group:community"],
                 ),
@@ -438,6 +439,7 @@ class TestPrepareOhosParam(SimpleTestCase):
             (
                 "parent selection",
                 (
+                    "list",
                     ["community"],
                     [
                         "collection:parent-collectionSurrey:Surrey History Centre",
@@ -457,6 +459,7 @@ class TestPrepareOhosParam(SimpleTestCase):
             (
                 "parent children selection",
                 (
+                    "list",
                     ["community"],
                     [
                         "collection:parent-collectionSurrey:Surrey History Centre",
@@ -480,6 +483,7 @@ class TestPrepareOhosParam(SimpleTestCase):
             (
                 "children selection",
                 (
+                    "list",
                     ["community"],
                     [
                         "collection:child-collectionSurrey:GYPSY ROMA TRAVELLER HISTORY MONTH: RECORDED INTERVIEWS",
@@ -498,11 +502,32 @@ class TestPrepareOhosParam(SimpleTestCase):
                     ],
                 ),
             ),
+            (
+                "parent children selection - MAP view",
+                (
+                    "map",
+                    ["community"],
+                    [
+                        "collection:parent-collectionSurrey:Surrey History Centre",
+                        "collection:child-collectionSurrey:GYPSY ROMA TRAVELLER HISTORY MONTH: RECORDED INTERVIEWS",
+                        "collection:child-collectionSurrey:LINGFIELD ORAL HISTORY PROJECT: TRANSCRIPTS",
+                        "collection:parent-collectionMorrab:Morrab Photo Archive",
+                        "collection:child-collectionMorrab:Miscellaneous Photos",
+                        "group:community",
+                    ],
+                ),
+                (
+                    ["community"],
+                    [
+                        "group:community",
+                    ],
+                ),
+            ),
         )
 
-        for label, value, expected in test_data:
+        for label, params, expected in test_data:
             with self.subTest(label):
-                aggs, filter = prepare_ohos_params(*value)
+                aggs, filter = prepare_ohos_params(*params)
                 aggs_equality = set(aggs).issubset(set(expected[0]))
                 filter_equality = set(filter).issubset(set(expected[1]))
                 self.assertTrue(aggs_equality)

--- a/etna/search/tests/test_views.py
+++ b/etna/search/tests/test_views.py
@@ -207,7 +207,8 @@ class CatalogueSearchAPIIntegrationTest(SearchViewTestCase):
         FEATURE_GEO_LON=f"{-54321.12345}",
         FEATURE_GEO_ZOOM=f"{3}",
     )
-    def test_context_data(self):
+    def test_context_data_map_view(self):
+        self.test_url = f"{self.test_url}?vis_view=map"
         response = self.client.get(self.test_url)
         self.assertEqual(
             response.context.get("default_geo_data"),
@@ -216,6 +217,32 @@ class CatalogueSearchAPIIntegrationTest(SearchViewTestCase):
                 "lon": settings.FEATURE_GEO_LON,
                 "zoom": settings.FEATURE_GEO_ZOOM,
             },
+        )
+
+    @responses.activate
+    @override_settings(
+        FEATURE_GEO_LAT=f"{12345.6789}",
+        FEATURE_GEO_LON=f"{-54321.12345}",
+        FEATURE_GEO_ZOOM=f"{3}",
+    )
+    def test_context_data_list_view(self):
+        self.test_url = f"{self.test_url}?vis_view=list"
+        response = self.client.get(self.test_url)
+        self.assertEqual(
+            response.context.get("list_view_url"),
+            "/search/catalogue/?group=community&vis_view=list",
+        )
+        self.assertEqual(
+            response.context.get("map_view_url"),
+            "/search/catalogue/?group=community&vis_view=map",
+        )
+        self.assertEqual(
+            response.context.get("timeline_view_url"),
+            "/search/catalogue/?group=community&vis_view=timeline&timeline_type=century",
+        )
+        self.assertEqual(
+            response.context.get("tag_view_url"),
+            "/search/catalogue/?group=community&vis_view=tag",
         )
 
     @responses.activate

--- a/etna/search/views.py
+++ b/etna/search/views.py
@@ -3,6 +3,7 @@ import importlib
 import logging
 import re
 
+from datetime import date
 from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 
 from django.conf import settings
@@ -10,6 +11,7 @@ from django.core.paginator import Page as PaginatorPage
 from django.forms import Form
 from django.http import Http404, HttpRequest, HttpResponse, HttpResponseBadRequest
 from django.utils import timezone
+from django.utils.http import urlencode
 from django.views.generic import FormView, TemplateView
 
 from wagtail.coreutils import camelcase_to_underscore
@@ -463,6 +465,7 @@ class BaseFilteredSearchView(BaseSearchView):
             offset=(self.page_number - 1) * page_size,
             size=page_size,
             sort=form.cleaned_data.get("sort"),
+            vis_view=form.cleaned_data.get("vis_view"),
         )
 
     def get_api_aggregations(self) -> List[str]:
@@ -787,25 +790,64 @@ class CatalogueSearchView(BucketsMixin, BaseFilteredSearchView):
     page_type = "Catalogue search page"
     page_title = "Catalogue search"
 
-    def get_context_data(self, **kwargs: Any) -> Dict[str, Any]:
-        self.set_session_info()
+    def _get_ohos_kwargs(self, **kwargs: Any) -> Dict[str, Any]:
+        """
+        Adds template tags for OHOS visualisation links
+        """
+        # params to append to the visual links template tags
+        _FIELDS_TO_ADD = (
+            "q",
+            "sort",
+            "collection",
+            "covering_date_from",
+            "covering_date_to",
+        )
+
         module = importlib.import_module("etna.search.common")
-        q_search_param = ""
-        if q_search_term := self.form.cleaned_data.get("q"):
-            q_search_param = "&q=" + q_search_term
+
+        vis_view = self.form.cleaned_data.get("vis_view")
+
+        if vis_view == VisViews.MAP:
+            kwargs.update(
+                default_geo_data={
+                    "lat": settings.FEATURE_GEO_LAT,
+                    "lon": settings.FEATURE_GEO_LON,
+                    "zoom": settings.FEATURE_GEO_ZOOM,
+                },
+            )
+
+        # update visualisation links with search and filters
+        add_url_params = ""
+        for field, data in self.form.cleaned_data.items():
+            if field in _FIELDS_TO_ADD and data:
+                if isinstance(data, str):
+                    add_url_params += f"&{urlencode({field:data})}"
+                elif isinstance(data, list):
+                    for item in data:
+                        add_url_params += f"&{urlencode({field:item})}"
+                elif isinstance(data, date):
+                    add_url_params += f"&{urlencode({f"{field}_0":str(data.day).zfill(2), 
+                                                    f"{field}_1":str(data.month).zfill(2), 
+                                                    f"{field}_2":str(data.year).zfill(4)})}"
 
         kwargs.update(
-            default_geo_data={
-                "lat": settings.FEATURE_GEO_LAT,
-                "lon": settings.FEATURE_GEO_LON,
-                "zoom": settings.FEATURE_GEO_ZOOM,
-            },
-            list_view_url=module.VIS_URLS.get(VisViews.LIST.value) + q_search_param,
-            map_view_url=module.VIS_URLS.get(VisViews.MAP.value) + q_search_param,
+            list_view_url=module.VIS_URLS.get(VisViews.LIST.value) + add_url_params,
+            map_view_url=module.VIS_URLS.get(VisViews.MAP.value) + add_url_params,
             timeline_view_url=module.VIS_URLS.get(VisViews.TIMELINE.value)
-            + q_search_param,
-            tag_view_url=module.VIS_URLS.get(VisViews.TAG.value) + q_search_param,
+            + add_url_params,
+            tag_view_url=module.VIS_URLS.get(VisViews.TAG.value) + add_url_params,
         )
+
+        return kwargs
+
+    def get_context_data(self, **kwargs: Any) -> Dict[str, Any]:
+        self.set_session_info()
+
+        if self.current_bucket_key == BucketKeys.COMMUNITY:
+
+            add_kwargs = self._get_ohos_kwargs(**kwargs)
+            kwargs.update(add_kwargs)
+
         return super().get_context_data(**kwargs)
 
 

--- a/etna/search/views.py
+++ b/etna/search/views.py
@@ -826,9 +826,12 @@ class CatalogueSearchView(BucketsMixin, BaseFilteredSearchView):
                     for item in data:
                         add_url_params += f"&{urlencode({field:item})}"
                 elif isinstance(data, date):
-                    add_url_params += f"&{urlencode({f"{field}_0":str(data.day).zfill(2), 
-                                                    f"{field}_1":str(data.month).zfill(2), 
-                                                    f"{field}_2":str(data.year).zfill(4)})}"
+                    date_params = {
+                        f"{field}_0": str(data.day).zfill(2),
+                        f"{field}_1": str(data.month).zfill(2),
+                        f"{field}_2": str(data.year).zfill(4),
+                    }
+                    add_url_params += f"&{urlencode(date_params)}"
 
         kwargs.update(
             list_view_url=module.VIS_URLS.get(VisViews.LIST.value) + add_url_params,


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/HERITAGE-328

## About these changes

- update visualisation view links to include filters
- Map view queries ciim by excluding filters

## How to check these changes

- enter search and filter via a visualisation view
Ex List view http://127.0.0.1:8000/search/catalogue/?covering_date_from_0=&covering_date_from_1=&covering_date_from_2=1900&covering_date_to_0=&covering_date_to_1=&covering_date_to_2=&collection=People%27s+Collection+Wales&collection=Sharing+Wycombe%27s+Old+Photographs&collection=parent-collectionMorrab%3AMorrab+Photo+Archive&collection=child-collectionMorrab%3AAngove+Collection&collection=child-collectionMorrab%3AMiscellaneous+Photos&q=royal&sort=&vis_view=list&group=community
- Clicking on any of the Visualisation views retains the search criteria - Ex click on List View, Map view, Timeline View, Tag view - the search filters are retained in that view.

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [x] Ensured that PR includes only commits relevant to the ticket
- [x] Waited for all CI jobs to pass before requesting a review
- [x] Added/updated tests and documentation where relevant

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
