### PR TITLE
HERITAGE-347: BE updates for Tag selection

### DIFF
--- a/etna/search/forms.py
+++ b/etna/search/forms.py
@@ -14,6 +14,7 @@ from ..ciim.constants import (  # TODO: Keep, not in scope for Ohos-Etna at this
     NESTED_CHILDREN_KEY,
     SEPERATOR,
     BucketKeys,
+    TagTypes,
 )
 from .templatetags.search_tags import is_see_more
 
@@ -322,6 +323,16 @@ class BaseCollectionSearchForm(forms.Form):
     # used for OHOS-Timeline View
     creation_date_from = forms.CharField(
         label="Creation from",
+        required=False,
+    )
+    # used for Tag View
+    chart_data_type = forms.ChoiceField(
+        choices=[
+            (TagTypes.LOCATION.value.upper(), TagTypes.LOCATION.name),
+            (TagTypes.PERSON.value.upper(), TagTypes.PERSON.name),
+            (TagTypes.ORGANISATION.value.upper(), TagTypes.ORGANISATION.name),
+            (TagTypes.MISCELLANEOUS.value.upper(), TagTypes.MISCELLANEOUS.name),
+        ],
         required=False,
     )
 

--- a/etna/search/templatetags/search_tags.py
+++ b/etna/search/templatetags/search_tags.py
@@ -18,6 +18,7 @@ from etna.ciim.constants import (
     SEPERATOR,
     BucketKeys,
     SearchTabs,
+    VisViews,
 )
 
 register = template.Library()
@@ -207,3 +208,26 @@ def long_filter_cancel(context, field_name: str = "") -> str:
         )
 
     return f'{reverse("search-catalogue")}?{query_dict.urlencode()}'
+
+
+@register.simple_tag(takes_context=True)
+def tag_type_url(context, tag_type: str | None = None) -> str:
+    """returns url link for the tag type of the tag view otherwise empty string"""
+    request = context["request"]
+
+    query_dict = request.GET.copy()
+
+    if (
+        query_dict.get("group", "") == BucketKeys.COMMUNITY
+        and query_dict.get("vis_view", "") == VisViews.TAG
+    ):
+        # reset the url to previous state - used with x on filter label
+        query_dict.pop("chart_data_type", None)
+
+        form_chart_data_type = context.get("form").cleaned_data.get("chart_data_type")
+        add_param = (
+            f"&chart_data_type={tag_type}" if tag_type != form_chart_data_type else ""
+        )
+        return f'{reverse("search-catalogue")}?{query_dict.urlencode()}{add_param}'
+
+    return ""

--- a/etna/search/views.py
+++ b/etna/search/views.py
@@ -37,6 +37,7 @@ from ..ciim.constants import (
     BucketList,
     Display,
     SearchTabs,
+    TagTypes,
     TimelineTypes,
     VisViews,
 )
@@ -360,6 +361,7 @@ class BaseSearchView(SearchDataLayerMixin, ClientAPIMixin, GETFormView):
             searchtabs=SearchTabs,
             vis_view=VisViews,
             timeline_type=TimelineTypes,
+            tag_type=TagTypes,
             display=Display,
             closure_closed_status=CLOSURE_CLOSED_STATUS,
             **kwargs,

--- a/templates/search/blocks/search_filters.html
+++ b/templates/search/blocks/search_filters.html
@@ -213,6 +213,8 @@
     {% if form.group.value == bucketkeys.COMMUNITY.value %}
         {% if form.vis_view.value == vis_view.TIMELINE %}
             {% render_fields_as_hidden form include='q group sort vis_view timeline_type creation_date_from' %}
+        {% elif form.vis_view.value == vis_view.TAG %}
+            {% render_fields_as_hidden form include='q group sort vis_view chart_data_type' %}
         {% else %}
             {% render_fields_as_hidden form include='q group sort vis_view' %}
         {% endif %}

--- a/templates/search/blocks/search_results_hero.html
+++ b/templates/search/blocks/search_results_hero.html
@@ -17,20 +17,22 @@
                             {% comment %}
                             {% render_fields_as_hidden form exclude='q opening_start_date opening_end_date filter_keyword' %}
                             {% endcomment %}
-                            {% render_fields_as_hidden form exclude='q' %}
+                            {% render_fields_as_hidden form exclude='q chart_data_type' %}
+                        {% elif form.vis_view.value == vis_view.TAG %}
+                            {% render_fields_as_hidden form exclude='q timeline_type creation_date_from' %}
                         {% else %}
                             {# TODO: Keep, not in scope for Ohos-Etna at this time #}
                             {% comment %}
                             {% render_fields_as_hidden form exclude='q opening_start_date opening_end_date filter_keyword timeline_type creation_date_from' %}
                             {% endcomment %}
-                            {% render_fields_as_hidden form exclude='q timeline_type creation_date_from' %}
+                            {% render_fields_as_hidden form exclude='q timeline_type creation_date_from chart_data_type' %}
                         {% endif %}
                     {% else %}
                         {# TODO: Keep, not in scope for Ohos-Etna at this time #}
                         {% comment %}
                         {% render_fields_as_hidden form exclude='q vis_view timeline_type creation_date_from' %}
                         {% endcomment %}
-                        {% render_fields_as_hidden form exclude='q vis_view timeline_type creation_date_from filter_keyword opening_start_date opening_end_date' %}
+                        {% render_fields_as_hidden form exclude='q vis_view timeline_type creation_date_from chart_data_type filter_keyword opening_start_date opening_end_date' %}
                     {% endif %}
                 
 

--- a/templates/search/blocks/search_results_tag_frequency.html
+++ b/templates/search/blocks/search_results_tag_frequency.html
@@ -6,7 +6,6 @@
         <ul class="tag-frequency__tags-list">
             <li>
                 <a href="{% tag_type_url tag_type=tag_type.LOCATION|upper %}" class="ohos-tag ohos-tag--location">
-                {% comment %} <a href="{% tag_type_url %}{% if form.chart_data_type.value != 'LOC' %}&chart_data_type=LOC{% endif %}" class="ohos-tag ohos-tag--location"> {% endcomment %}
                     <span class="ohos-tag__inner">
                         Location
                         {% if form.chart_data_type.value == 'LOC' %}
@@ -18,7 +17,6 @@
 
             <li>
                 <a href="{% tag_type_url tag_type=tag_type.PERSON|upper %}" class="ohos-tag ohos-tag--person">
-                {% comment %} <a href="{% tag_type_url %}{% if form.chart_data_type.value != 'PER' %}&chart_data_type=PER{% endif %}"" class="ohos-tag ohos-tag--person"> {% endcomment %}
                     <span class="ohos-tag__inner">
                         Person
                         {% if form.chart_data_type.value == 'PER' %}
@@ -30,7 +28,6 @@
 
             <li>
                 <a href="{% tag_type_url tag_type=tag_type.ORGANISATION|upper %}" class="ohos-tag ohos-tag--organisation">
-                {% comment %} <a href="{% tag_type_url %}{% if form.chart_data_type.value != 'ORG' %}&chart_data_type=ORG{% endif %}" class="ohos-tag ohos-tag--organisation"> {% endcomment %}
                     <span class="ohos-tag__inner">
                         Organisation
                         {% if form.chart_data_type.value == 'ORG' %}
@@ -42,7 +39,6 @@
 
             <li>
                 <a href="{% tag_type_url tag_type=tag_type.MISCELLANEOUS|upper %}" class="ohos-tag ohos-tag--misc">
-                {% comment %} <a href="{% tag_type_url %}{% if form.chart_data_type.value != 'MISC' %}&chart_data_type=MISC{% endif %}" class="ohos-tag ohos-tag--misc"> {% endcomment %}
                     <span class="ohos-tag__inner">
                         Miscellaneous
                         {% if form.chart_data_type.value == 'MISC' %}

--- a/templates/search/blocks/search_results_tag_frequency.html
+++ b/templates/search/blocks/search_results_tag_frequency.html
@@ -5,7 +5,8 @@
         <p class="tag-frequency__title">Filter by:</p>
         <ul class="tag-frequency__tags-list">
             <li>
-                <a href="/search/catalogue/?group=community&vis_view=tag{% if form.chart_data_type.value != 'LOC' %}&chart_data_type=LOC{% endif %}" class="ohos-tag ohos-tag--location">
+                <a href="{% tag_type_url tag_type=tag_type.LOCATION|upper %}" class="ohos-tag ohos-tag--location">
+                {% comment %} <a href="{% tag_type_url %}{% if form.chart_data_type.value != 'LOC' %}&chart_data_type=LOC{% endif %}" class="ohos-tag ohos-tag--location"> {% endcomment %}
                     <span class="ohos-tag__inner">
                         Location
                         {% if form.chart_data_type.value == 'LOC' %}
@@ -16,7 +17,8 @@
             </li>
 
             <li>
-                <a href="/search/catalogue/?group=community&vis_view=tag{% if form.chart_data_type.value != 'PER' %}&chart_data_type=PER{% endif %}" class="ohos-tag ohos-tag--person">
+                <a href="{% tag_type_url tag_type=tag_type.PERSON|upper %}" class="ohos-tag ohos-tag--person">
+                {% comment %} <a href="{% tag_type_url %}{% if form.chart_data_type.value != 'PER' %}&chart_data_type=PER{% endif %}"" class="ohos-tag ohos-tag--person"> {% endcomment %}
                     <span class="ohos-tag__inner">
                         Person
                         {% if form.chart_data_type.value == 'PER' %}
@@ -27,7 +29,8 @@
             </li>
 
             <li>
-                <a href="/search/catalogue/?group=community&vis_view=tag{% if form.chart_data_type.value != 'ORG' %}&chart_data_type=ORG{% endif %}" class="ohos-tag ohos-tag--organisation">
+                <a href="{% tag_type_url tag_type=tag_type.ORGANISATION|upper %}" class="ohos-tag ohos-tag--organisation">
+                {% comment %} <a href="{% tag_type_url %}{% if form.chart_data_type.value != 'ORG' %}&chart_data_type=ORG{% endif %}" class="ohos-tag ohos-tag--organisation"> {% endcomment %}
                     <span class="ohos-tag__inner">
                         Organisation
                         {% if form.chart_data_type.value == 'ORG' %}
@@ -38,7 +41,8 @@
             </li>
 
             <li>
-                <a href="/search/catalogue/?group=community&vis_view=tag{% if form.chart_data_type.value != 'MISC' %}&chart_data_type=MISC{% endif %}" class="ohos-tag ohos-tag--misc">
+                <a href="{% tag_type_url tag_type=tag_type.MISCELLANEOUS|upper %}" class="ohos-tag ohos-tag--misc">
+                {% comment %} <a href="{% tag_type_url %}{% if form.chart_data_type.value != 'MISC' %}&chart_data_type=MISC{% endif %}" class="ohos-tag ohos-tag--misc"> {% endcomment %}
                     <span class="ohos-tag__inner">
                         Miscellaneous
                         {% if form.chart_data_type.value == 'MISC' %}

--- a/templates/search/blocks/search_sort_and_view_options.html
+++ b/templates/search/blocks/search_sort_and_view_options.html
@@ -20,20 +20,22 @@
                 {% comment %}
                 {% render_fields_as_hidden form exclude='sort opening_start_date opening_end_date filter_keyword' %}
                 {% endcomment %}
-                {% render_fields_as_hidden form exclude='sort' %}
+                {% render_fields_as_hidden form exclude='sort chart_data_type' %}
+            {% elif form.vis_view.value == vis_view.TAG %}
+                {% render_fields_as_hidden form exclude='sort timeline_type creation_date_from' %}
             {% else %}
                 {# TODO: Keep, not in scope for Ohos-Etna at this time #}
                 {% comment %}
                 {% render_fields_as_hidden form exclude='sort opening_start_date opening_end_date filter_keyword timeline_type creation_date_from' %}
                 {% endcomment %}
-                {% render_fields_as_hidden form exclude='sort timeline_type creation_date_from' %}
+                {% render_fields_as_hidden form exclude='sort timeline_type creation_date_from chart_data_type' %}
             {% endif %}
         {% else %}
             {# TODO: Keep, not in scope for Ohos-Etna at this time #}
             {% comment %}
             {% render_fields_as_hidden form exclude='sort vis_view timeline_type creation_date_from' %}
             {% endcomment %}
-            {% render_fields_as_hidden form exclude='sort vis_view timeline_type creation_date_from opening_start_date opening_end_date filter_keyword' %}
+            {% render_fields_as_hidden form exclude='sort vis_view timeline_type chart_data_type creation_date_from opening_start_date opening_end_date filter_keyword' %}
         {% endif %}
 
         <input type="submit" value="Sort by" class="search-sort-view__form-submit">


### PR DESCRIPTION
Ticket URL:  https://national-archives.atlassian.net/browse/HERITAGE-347

## About these changes

- Add `chart_data_type` form element, and hidden fields across all forms
- Update Filter by/Category/Chart Data Type/Tag type url links
    - to handle tag selection with all filter params
    - to handle tag deselection

## How to check these changes

- Navigate to [Tag view](http://127.0.0.1:8000/search/catalogue/?group=community&vis_view=tag) - add search query, refine filters
- Select a [Tag to filter by](http://127.0.0.1:8000/search/catalogue/?group=community&vis_view=tag&chart_data_type=PER) - page should reload and any search filters should be retained
- Unselect the Tag that is filtered - should return to state before selecting the Tag

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [x] Ensured that PR includes only commits relevant to the ticket
- [x] Waited for all CI jobs to pass before requesting a review
- [x] Added/updated tests and documentation where relevant

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
