### PR TITLE
HERITAGE-348: BE tag visualisation - updated to one template var

### DIFF
--- a/etna/ciim/constants.py
+++ b/etna/ciim/constants.py
@@ -55,13 +55,14 @@ DEFAULT_AGGREGATIONS = [
     # TODO:Rosetta + ":30",  # Fetch more 'groups' so that we receive counts for any bucket/tab options we might be showing.
 ]
 
-TAG_VIEW_AGGREGATIONS = [
-    Aggregation.COMMUNITY.value,
-    Aggregation.ENRICHMENT_LOC.value,
-    Aggregation.ENRICHMENT_PER.value,
-    Aggregation.ENRICHMENT_ORG.value,
-    Aggregation.ENRICHMENT_MISC.value,
+ENRICHMENT_AGGREGATIONS = [
+    Aggregation.ENRICHMENT_LOC,
+    Aggregation.ENRICHMENT_PER,
+    Aggregation.ENRICHMENT_ORG,
+    Aggregation.ENRICHMENT_MISC,
 ]
+
+TAG_VIEW_AGGREGATIONS = [Aggregation.COMMUNITY] + ENRICHMENT_AGGREGATIONS
 
 
 @dataclass

--- a/etna/search/tests/test_views.py
+++ b/etna/search/tests/test_views.py
@@ -12,6 +12,7 @@ from wagtail.test.utils import WagtailTestUtils
 
 import responses
 
+from etna.ciim.constants import ENRICHMENT_AGGREGATIONS
 from etna.core.test_utils import prevent_request_warnings
 
 from ..forms import CatalogueSearchForm
@@ -701,10 +702,7 @@ class CatalogueSearchEndToEndTest(EndToEndSearchTestCase):
         chart_data_type_hidden = """<input type="hidden" name="chart_data_type" value="LOC" id="id_chart_data_type_123">"""
         self.assertContains(response, chart_data_type_hidden, count=0, status_code=200)
 
-        self.assertFalse((response.context.get("enrichment_loc_aggs")))
-        self.assertFalse((response.context.get("enrichment_per_aggs")))
-        self.assertFalse((response.context.get("enrichment_org_aggs")))
-        self.assertFalse((response.context.get("enrichment_misc_aggs")))
+        self.assertFalse((response.context.get("enrichment_aggs")))
 
     @mock.patch(
         "etna.search.templatetags.search_tags.get_random_string", return_value="123"
@@ -762,10 +760,13 @@ class CatalogueSearchEndToEndTest(EndToEndSearchTestCase):
 
         self.assertEqual(len(response.context.get("selected_filters")), 2)
 
-        self.assertTrue(len(response.context.get("enrichment_loc_aggs")))
-        self.assertTrue(len(response.context.get("enrichment_per_aggs")))
-        self.assertTrue(len(response.context.get("enrichment_org_aggs")))
-        self.assertTrue(len(response.context.get("enrichment_misc_aggs")))
+        self.assertEqual(len(response.context.get("enrichment_aggs")), 4)
+
+        for aggs in response.context.get("enrichment_aggs"):
+            self.assertTrue(
+                aggs.get("name") in ENRICHMENT_AGGREGATIONS,
+                msg="enrichment_aggs name not found",
+            )
 
 
 class CatalogueSearchLongFilterChooserAPIIntegrationTest(SearchViewTestCase):

--- a/etna/search/views.py
+++ b/etna/search/views.py
@@ -25,6 +25,7 @@ from ..ciim.constants import (
     CHILD_AGGS_PREFIX,
     CLOSURE_CLOSED_STATUS,
     COLLECTION_ATTR_FOR_ALL_BUCKETS,
+    ENRICHMENT_AGGREGATIONS,
     LONG_AGGS_PREFIX,
     NESTED_CHECKBOX_VALUES_AGGS_NAMES_MAP,
     NESTED_CHILDREN_KEY,
@@ -977,17 +978,13 @@ class CatalogueSearchView(BucketsMixin, BaseFilteredSearchView):
 
         vis_view = self.form.cleaned_data.get("vis_view")
         if vis_view == VisViews.TAG:
+            enrichment_aggs = []
             for aggs_rec in self.api_result.aggregations:
                 aggs = aggs_rec.get("name")
-                if aggs == Aggregation.ENRICHMENT_LOC:
-                    kwargs.update(enrichment_loc_aggs=aggs_rec.get("entries", []))
-                elif aggs == Aggregation.ENRICHMENT_PER:
-                    kwargs.update(enrichment_per_aggs=aggs_rec.get("entries", []))
-                elif aggs == Aggregation.ENRICHMENT_ORG:
-                    kwargs.update(enrichment_org_aggs=aggs_rec.get("entries", []))
-                elif aggs == Aggregation.ENRICHMENT_MISC:
-                    kwargs.update(enrichment_misc_aggs=aggs_rec.get("entries", []))
-
+                if aggs in ENRICHMENT_AGGREGATIONS:
+                    enrichment_aggs.append(aggs_rec)
+                if enrichment_aggs:
+                    kwargs.update(enrichment_aggs=enrichment_aggs)
         return kwargs
 
     def get_api_aggregations(self) -> List[str]:


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/HERITAGE-348

## About these changes

- Update the 4 template var for enrichment aggregations to one variable. 
i.e. `enrichment_aggs` 
The var contain enrichment aggregation data which will be used to replace the static data file for Tag visualisation. These are update on each page load.
- Updated tests

## How to check these changes

`enrichment_aggs`  to be integrated into FE

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [x] Ensured that PR includes only commits relevant to the ticket
- [x] Waited for all CI jobs to pass before requesting a review
- [x] Added/updated tests and documentation where relevant

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
