### PR TITLE
HERITAGE-375: nested filters wmk

### DIFF
--- a/etna/ciim/constants.py
+++ b/etna/ciim/constants.py
@@ -765,6 +765,7 @@ For the nested filter: <collection-name/ciim-value>:(<ciim-aggs-name:at-pos-1>,<
 NESTED_CHECKBOX_VALUES_AGGS_NAMES_MAP = {
     "Surrey History Centre": ("collectionSurrey", "collectionSurreyAll"),
     "Morrab Photo Archive": ("collectionMorrab", "collectionMorrabAll"),
+    "Milton Keynes City Discovery Centre": ("collectionWMK", ""),
 }
 
 # prefix ends with "-"

--- a/etna/ciim/tests/test_utils.py
+++ b/etna/ciim/tests/test_utils.py
@@ -597,6 +597,27 @@ class TestPrepareOhosParam(SimpleTestCase):
                     ],
                 ),
             ),
+            (
+                "parent children selection - WMK",  # label
+                # params
+                (
+                    "list",
+                    ["community"],
+                    [
+                        "collection:parent-collectionWMK:Milton Keynes City Discovery Centre",
+                        "collection:child-collectionWMK:Women who made Milton Keynes",
+                        "group:community",
+                    ],
+                ),
+                # expected
+                (
+                    ["community", "collectionWMK"],
+                    [
+                        "collectionOhos:Women who made Milton Keynes",
+                        "group:community",
+                    ],
+                ),
+            ),
         )
 
         for label, params, expected in test_data:


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/HERITAGE-375

## About these changes

- Adds new config for nested filters for WMK in `NESTED_CHECKBOX_VALUES_AGGS_NAMES_MAP`
- Adds tests

## How to check these changes

http://127.0.0.1:8000/search/catalogue/?group=community&vis_view=list&collection=parent-collectionWMK%3AMilton+Keynes+City+Discovery+Centre&collection=child-collectionWMK%3AWomen+who+made+Milton+Keynes

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [x] Ensured that PR includes only commits relevant to the ticket
- [x] Waited for all CI jobs to pass before requesting a review
- [x] Added/updated tests and documentation where relevant

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
