### PR TITLE
HERITAGE-381: integrate moloney data

### DIFF
--- a/etna/ciim/constants.py
+++ b/etna/ciim/constants.py
@@ -769,6 +769,7 @@ class CommunityCollectionMapping(StrEnum):
         "wmk-0",
         "https://catalogue.mkcdc.org.uk/",
     )
+    # NOTE: CAIN Archive has multiple ciim prefixed ids ex sid-0 (Community level), me-0 (Collection level)
     SID = ("CAIN Archive - Conflict and Politics in Northern Ireland", "sid-0", "")
 
     def __new__(cls, value, community_level_ciim_id, webpage_url):

--- a/etna/records/converters.py
+++ b/etna/records/converters.py
@@ -41,6 +41,7 @@ class IDConverter(StringConverter):
         r"|osc-[a-zA-Z0-9\-\.]{1,}"
         r"|mpa-[0-9]{1,}"
         r"|sid-[a-zA-Z0-9\-\.]{1,}"
+        r"|me-[a-zA-Z0-9\-\.]{1,}"
     )
     etna_pattern = (
         "[ACDFN][0-9]{1,8}|[a-f0-9]{8}-?([a-f0-9]{4}-?){3}[a-f0-9]{12}(_[1-9])?"

--- a/etna/records/tests/test_id_formats.py
+++ b/etna/records/tests/test_id_formats.py
@@ -26,6 +26,7 @@ class TestIDFormats(SimpleTestCase):
             ("ohos-shc-2", "shc-CC1174-2-1-1-1"),
             ("ohos-mpa", "mpa-12345"),
             ("ohos-sid", "sid-12345"),
+            ("ohos-me", "me-12345"),
         ):
             id_regex = re.compile(IDConverter.regex)
             with self.subTest(label):

--- a/etna/records/tests/test_models.py
+++ b/etna/records/tests/test_models.py
@@ -707,6 +707,33 @@ class CommunityRecordCollectionAttrTests(SimpleTestCase):
                     "community_collection_webpage": {},
                 },
             ),
+            (
+                # label
+                "me: Collection level for me-0",
+                # value
+                {
+                    "@template": {
+                        "details": {
+                            "ciimId": "me-0",
+                            "level": "Collection",
+                            "collectionId": "sid-0",
+                            "collection": "some value",
+                            "group": "community",
+                            "description": "description",
+                        }
+                    }
+                },
+                # expected
+                {
+                    "community_collection": {
+                        "label": "Collection",
+                        "value": "some value",
+                        "url": "/catalogue/id/sid-0/",
+                        "is_ext_url": False,
+                    },
+                    "community_collection_webpage": {},
+                },
+            ),
         )
         for label, data, expected in test_data:
             with self.subTest(label):


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/HERITAGE-381

## About these changes

- Configures new ciim id
- Update tests
- **NOTE**: CAIN Archive has multiple ciim prefixed ids ex sid-0 (Community level), me-0 (Collection level)

Dev notes:
ciim id = `me-{id}`
"Collection" level ciim id => `me-0`

me-api data shows under SID
Nested archive/collection abbrev => `SID` (Top level is Community)
Nested filter name => CAIN Archive - Conflict and Politics in Northern Ireland
"Community" level ciim id => `sid-0`
aggs alias => `collectionCain`
filter alias => `collectionOhos`


## How to check these changes

- Navigate to search
- Select "CAIN Archive - Conflict and Politics in Northern Ireland" and Update filter - It should show as nested collection containing "The Northern Ireland Political Ephemera Collection of Peter Moloney"
- Select "The Northern Ireland Political Ephemera Collection of Peter Moloney"
- Select a record from search results - It should show details page.


## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [x] Ensured that PR includes only commits relevant to the ticket
- [x] Waited for all CI jobs to pass before requesting a review
- [x] Added/updated tests and documentation where relevant

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
