### PR TITLE
Retrofit Fix from OHOS:deploy fix for ModuleNotFoundError: No module named poetry

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -9,6 +9,10 @@ name: app
 # to find the supported versions for the 'python' type.
 type: 'python:3.12'
 
+dependencies:
+  python3:
+    poetry: '1.8.1'
+
 variables:
   env:
     DJANGO_SETTINGS_MODULE: 'config.settings.platform'
@@ -37,17 +41,8 @@ hooks:
     # Download the latest version of pip
     python3.12 -m pip install --upgrade pip
 
-    # Install and configure Poetry
-    # Set user to false to install Poetry globally
-    export PIP_USER=false
-    curl -sSL https://install.python-poetry.org | python3 - --version $POETRY_VERSION
-    # Update PATH to make Poetry available in this hook
-    export PATH="/app/.local/bin:$PATH"
-    # Set user to true to install dependencies only in the virtual environment
-    export PIP_USER=true
-
     # Install dependencies
-    /app/.local/bin/poetry install --only main
+    poetry install --only main
 
     # Install NVM
     unset NPM_CONFIG_PREFIX
@@ -61,9 +56,9 @@ hooks:
     cp -R node_modules/@nationalarchives/frontend/nationalarchives/assets/* templates/static/assets
     npm run compile
 
-    /app/.local/bin/poetry run python manage.py collectstatic --no-input
+    poetry run python manage.py collectstatic --no-input
   deploy: |
-    /app/.local/bin/poetry run python manage.py migrate
+    poetry run python manage.py migrate
 
 web:
   upstream:


### PR DESCRIPTION
Ticket URL: NA

## About these changes

Retrofit fix from `OHOS` branch

Fixes deploy issue to plaform.sh

     webpack 5.91.0 compiled with 3 warnings in 18537 ms
     W: Traceback (most recent call last):
     W:   File "/app/.global/bin/poetry", line 5, in <module>
     W:     from poetry.console.application import main
     W: ModuleNotFoundError: No module named 'poetry'
   
   E: Error building project: Step failed with status code 1.
 
 E: Error: Unable to build application, aborting.

## How to check these changes

Deploy to platform.sh

## Before assigning to reviewer, please make sure you have

- [ ] Checked things thoroughly before handing over to reviewer
- [ ] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [ ] Ensured that PR includes only commits relevant to the ticket
- [ ] Waited for all CI jobs to pass before requesting a review
- [ ] Added/updated tests and documentation where relevant

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
