### PR TITLE
HERITAGE-405: Fix CodeBlock styling

### DIFF
--- a/sass/ohos/_code.scss
+++ b/sass/ohos/_code.scss
@@ -3,7 +3,7 @@ pre code {
     padding: 20px;
 }
 
-pre {
+pre:has(code) {
     background-color: #eee;
     border: 1px solid #999;
 }


### PR DESCRIPTION
Ticket URL: [HERITAGE-405]

## About these changes

Fixed the background and border on the pre rather than the code to stop code escaping the borders

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [x] Ensured that PR includes only commits relevant to the ticket
- [x] Waited for all CI jobs to pass before requesting a review
- [x] Added/updated tests and documentation where relevant

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)


[HERITAGE-405]: https://national-archives.atlassian.net/browse/HERITAGE-405?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ