### PR TITLE
HERITAGE-386-warning-icon-on-details-page

### DIFF
--- a/sass/ohos/_search-results-map.scss
+++ b/sass/ohos/_search-results-map.scss
@@ -19,8 +19,7 @@
         &-icon {
             @include colour.colour-font("font-dark");
             padding-right: 0.5rem;
-           //  height: 3em;
-
+            //  height: 3em;
         }
     }
 }

--- a/sass/ohos/_search-results-map.scss
+++ b/sass/ohos/_search-results-map.scss
@@ -19,7 +19,8 @@
         &-icon {
             @include colour.colour-font("font-dark");
             padding-right: 0.5rem;
-            height: 3em;
+           //  height: 3em;
+
         }
     }
 }


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/jira/software/c/projects/HERITAGE/issues/HERITAGE-386

## About these changes

Height / padding adjustment to warning icon (fix).

## How to check these changes

Run branch locally 
Check a details page that has a named entity associated with it, 
Example : http://localhost:8000/catalogue/id/pcw-779721/


## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [x] Ensured that PR includes only commits relevant to the ticket
- [x] Waited for all CI jobs to pass before requesting a review
- [x] Added/updated tests and documentation where relevant

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
