### PR TITLE
HERITAGE-410-filters-breakpoint

### DIFF
--- a/sass/includes/search/_search-results.scss
+++ b/sass/includes/search/_search-results.scss
@@ -129,7 +129,7 @@
             outline: 5px solid $color__focus-outline-light-bg;
         }
 
-        @media only screen and (max-width: $screen__xl) {
+        @media only screen and (max-width: $screen__lg) {
             background: $color__black;
             color: $color__white;
             margin-left: 0.5rem;

--- a/scripts/src/modules/search/mobile-filter-expander-enhanced.js
+++ b/scripts/src/modules/search/mobile-filter-expander-enhanced.js
@@ -1,5 +1,4 @@
 /* global $buttonHtml $noOfFilters */
-alert("called");
 import debounce from "../debounce.js";
 
 export default function () {

--- a/scripts/src/modules/search/mobile-filter-expander-enhanced.js
+++ b/scripts/src/modules/search/mobile-filter-expander-enhanced.js
@@ -1,5 +1,5 @@
 /* global $buttonHtml $noOfFilters */
-alert('called');
+alert("called");
 import debounce from "../debounce.js";
 
 export default function () {

--- a/scripts/src/modules/search/mobile-filter-expander-enhanced.js
+++ b/scripts/src/modules/search/mobile-filter-expander-enhanced.js
@@ -1,5 +1,5 @@
 /* global $buttonHtml $noOfFilters */
-
+alert('called');
 import debounce from "../debounce.js";
 
 export default function () {
@@ -62,7 +62,7 @@ export default function () {
         }
     });
 
-    if (window.innerWidth <= 1200) {
+    if (window.innerWidth <= 1025) {
         $showHideButton.hidden = false;
         $searchFilterContainer.hidden = true;
     }
@@ -71,7 +71,7 @@ export default function () {
         "resize",
         debounce(() => {
             let ariaExpanded = $showHideButton.getAttribute("aria-expanded");
-            if (window.innerWidth <= 1200) {
+            if (window.innerWidth <= 1025) {
                 $showHideButton.hidden = false;
 
                 if (ariaExpanded === "false") {


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/jira/software/c/projects/HERITAGE/issues/HERITAGE-410

## About these changes

Changing the breakpoint so mobile filters appear at 992px

## How to check these changes

Run branch locally
Check that filter view changes at 992px width

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [x] Ensured that PR includes only commits relevant to the ticket
- [x] Waited for all CI jobs to pass before requesting a review
- [x] Added/updated tests and documentation where relevant

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
