### PR TITLE
HERITAGE-319: Apply filters to timeline results

### DIFF
--- a/scripts/src/modules/timeline/timeline.js
+++ b/scripts/src/modules/timeline/timeline.js
@@ -1,6 +1,23 @@
-fetch(
-    "https://tna.rosetta.k-int.com/rosetta/data/search?aggs=century&filter=group:community",
-) //  server-side API endpoint
+const searchParams = new URLSearchParams(window.location.search);
+
+var url_string =
+    "https://tna.rosetta.k-int.com/rosetta/data/search?aggs=century,community&filter=group%3Acommunity";
+
+var query = searchParams.get("q");
+
+if (query) {
+    url_string += "&q=" + query;
+}
+
+var collection = searchParams.get("collection");
+
+if (collection) {
+    url_string +=
+        "&filter=collectionOhos%3A" +
+        collection.substring(collection.indexOf(":") + 1).replace(/ /g, "+");
+}
+
+fetch(url_string) //  server-side API endpoint
     .then((response) => response.json())
     .then((data) => {
         const centuries = [];


### PR DESCRIPTION
Ticket URL: [HERITAGE-319]

## About these changes

Added q and collection filters to the URL string used in timeline.js

## How to check these changes

Compile JS, go to search, enter timeline view, and use search term and collection filters and see that the timeline view is updated. Records without dates will be excluded, which is why the MK filter has no results.

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [x] Ensured that PR includes only commits relevant to the ticket
- [x] Waited for all CI jobs to pass before requesting a review
- [x] Added/updated tests and documentation where relevant

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
