### PR TITLE
heritage-420: integrate aoc filter record

### DIFF
--- a/etna/ciim/constants.py
+++ b/etna/ciim/constants.py
@@ -771,6 +771,7 @@ class CommunityCollectionMapping(StrEnum):
     )
     # NOTE: CAIN Archive has multiple ciim prefixed ids ex sid-0 (Community level), me-0 (Collection level)
     SID = ("CAIN Archive - Conflict and Politics in Northern Ireland", "sid-0", "")
+    AOC = ("Accounts of the Conflict", "aoc-0", "")
 
     def __new__(cls, value, community_level_ciim_id, webpage_url):
         obj = str.__new__(cls, [value])
@@ -794,6 +795,7 @@ NESTED_CHECKBOX_VALUES_AGGS_NAMES_MAP = {
     CommunityCollectionMapping.MPA.value: ("collectionMorrab", "collectionMorrabAll"),
     CommunityCollectionMapping.WMK.value: ("collectionWMK", ""),
     CommunityCollectionMapping.SID.value: ("collectionCain", ""),
+    CommunityCollectionMapping.AOC.value: ("collectionConflict", ""),
 }
 
 # prefix ends with "-"

--- a/etna/ciim/tests/test_utils.py
+++ b/etna/ciim/tests/test_utils.py
@@ -639,6 +639,27 @@ class TestPrepareOhosParam(SimpleTestCase):
                     ],
                 ),
             ),
+            (
+                "parent children selection - AOC",  # label
+                # params
+                (
+                    "list",
+                    ["community"],
+                    [
+                        "collection:parent-collectionConflict:Accounts of the Conflict",
+                        "collection:child-collectionConflict:Bear in Mind: Stories of the Troubles",
+                        "group:community",
+                    ],
+                ),
+                # expected
+                (
+                    ["community", "collectionConflict"],
+                    [
+                        "collectionOhos:Bear in Mind: Stories of the Troubles",
+                        "group:community",
+                    ],
+                ),
+            ),
         )
 
         for label, params, expected in test_data:

--- a/etna/records/converters.py
+++ b/etna/records/converters.py
@@ -42,6 +42,7 @@ class IDConverter(StringConverter):
         r"|mpa-[0-9]{1,}"
         r"|sid-[a-zA-Z0-9\-\.]{1,}"
         r"|me-[a-zA-Z0-9\-\.]{1,}"
+        r"|aoc-[0-9]{1,}"
     )
     etna_pattern = (
         "[ACDFN][0-9]{1,8}|[a-f0-9]{8}-?([a-f0-9]{4}-?){3}[a-f0-9]{12}(_[1-9])?"

--- a/etna/records/tests/test_id_formats.py
+++ b/etna/records/tests/test_id_formats.py
@@ -27,6 +27,7 @@ class TestIDFormats(SimpleTestCase):
             ("ohos-mpa", "mpa-12345"),
             ("ohos-sid", "sid-12345"),
             ("ohos-me", "me-12345"),
+            ("ohos-aoc", "aoc-12345"),
         ):
             id_regex = re.compile(IDConverter.regex)
             with self.subTest(label):


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/HERITAGE-420

## About these changes

Configures new ciim id
Configures new collection
Update tests

Dev notes:
ciim id = aoc-{id}
Nested archive/collection abbrev => AOC
Nested filter name => `Accounts of the Conflict`
"Community" level ciim id => aoc-0
aggs alias => `collectionConflict`
filter alias => `collectionOhos`

## How to check these changes

- Navigate to search
- Select `Accounts of the Conflict` and Update filter - It should show as nested collection
- Select a record from search results - It should show details page.

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [x] Ensured that PR includes only commits relevant to the ticket
- [x] Waited for all CI jobs to pass before requesting a review
- [x] Added/updated tests and documentation where relevant

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
