### PR TITLE
HERITAGE-423:remove count label from see all

### DIFF
--- a/etna/search/forms.py
+++ b/etna/search/forms.py
@@ -60,8 +60,8 @@ class DynamicMultipleChoiceField(forms.MultipleChoiceField):
             value = data["value"]
             label = f"{value} ({count})"
             if is_see_all(value):
-                # prepare see all label with count
-                label = value.split(SEPERATOR)[1] + f" ({count})"
+                # prepare see all label
+                label = value.split(SEPERATOR)[1]
             return label
 
     def update_choices(

--- a/etna/search/tests/test_views.py
+++ b/etna/search/tests/test_views.py
@@ -661,7 +661,7 @@ class CatalogueSearchEndToEndTest(EndToEndSearchTestCase):
         )
         # see all url - Note: updated \' to \\\'
         self.assertIn(
-            """<a href="/search/catalogue/long-filter-chooser/collection/?collection=long-collectionMorrabAll%3AMorrab+Photo+Archive&amp;q=and&amp;collection=parent-collectionMorrab%3AMorrab+Photo+Archive&amp;collection=parent-collectionSurrey%3ASurrey+History+Centre&amp;collection=child-collectionSurrey%3AJENNIFER+LOUIS+OF+WESTHUMBLE%3A+ORAL+HISTORY+RECORDINGS&amp;collection=Biography+of+Women+Who+Made+Milton+Keynes+%28Digital+Document%29&amp;covering_date_from_0=01&amp;covering_date_from_1=01&amp;covering_date_from_2=1900&amp;sort=title%3Aasc&amp;vis_view=list&amp;group=community" aria-label=\\\'See more\\\'>See all collections (126)</a>""",
+            """<a href="/search/catalogue/long-filter-chooser/collection/?collection=long-collectionMorrabAll%3AMorrab+Photo+Archive&amp;q=and&amp;collection=parent-collectionMorrab%3AMorrab+Photo+Archive&amp;collection=parent-collectionSurrey%3ASurrey+History+Centre&amp;collection=child-collectionSurrey%3AJENNIFER+LOUIS+OF+WESTHUMBLE%3A+ORAL+HISTORY+RECORDINGS&amp;collection=Biography+of+Women+Who+Made+Milton+Keynes+%28Digital+Document%29&amp;covering_date_from_0=01&amp;covering_date_from_1=01&amp;covering_date_from_2=1900&amp;sort=title%3Aasc&amp;vis_view=list&amp;group=community" aria-label=\\\'See more\\\'>See all collections</a>""",
             content,
         )
         # orphan collection checked


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/HERITAGE-423

## About these changes

Remove count label for OHOS see all collections links

## How to check these changes

- Filter a nested collection having [see all link](http://127.0.0.1:8000/search/catalogue/?covering_date_from_0=&covering_date_from_1=&covering_date_from_2=&covering_date_to_0=&covering_date_to_1=&covering_date_to_2=&collection=parent-collectionMorrab%3AMorrab+Photo+Archive&q=royal&sort=&vis_view=list&group=community)
- Regression test see all link - with search term, filters, long filters
   

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [x] Ensured that PR includes only commits relevant to the ticket
- [x] Waited for all CI jobs to pass before requesting a review
- [x] Added/updated tests and documentation where relevant

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
