### PR TITLE
HERITAGE-319: Fix timeline index

### DIFF
--- a/scripts/src/modules/timeline/century.js
+++ b/scripts/src/modules/timeline/century.js
@@ -17,7 +17,6 @@ if (collection) {
         collection.substring(collection.indexOf(":") + 1).replace(/ /g, "+");
 }
 
-
 fetch(url_string) //  server-side API endpoint
     .then((response) => response.json())
     .then((data) => {
@@ -124,8 +123,7 @@ fetch(url_string) //  server-side API endpoint
                 searchParams.set("timeline_type", "year");
                 searchParams.set("startDate", targetDecade.decade);
 
-                const url =
-                    "./?" + searchParams.toString() + "#myChart";
+                const url = "./?" + searchParams.toString() + "#myChart";
                 console.log(url);
                 window.location = url;
             }

--- a/scripts/src/modules/timeline/century.js
+++ b/scripts/src/modules/timeline/century.js
@@ -118,15 +118,11 @@ fetch(url_string) //  server-side API endpoint
             );
             if (activePoints.length > 0) {
                 // Get the clicked bar index
-                const clickedIndex = activePoints[0].index * 10;
+                const targetDecade = decades[activePoints[0].index];
                 // clickedIndexAdjust = targetCentury + clickedIndex;
-                const clickedIndexAdjust = targetCentury + clickedIndex;
-                // console.log(clickedIndexAdjust);
-                // Access the corresponding record count from chart data
-                // const recordCount = chartData[clickedIndex];
                 var searchParams = new URLSearchParams(window.location.search);
                 searchParams.set("timeline_type", "year");
-                searchParams.set("startDate", clickedIndexAdjust);
+                searchParams.set("startDate", targetDecade.decade);
 
                 const url =
                     "./?" + searchParams.toString() + "#myChart";

--- a/scripts/src/modules/timeline/century.js
+++ b/scripts/src/modules/timeline/century.js
@@ -1,6 +1,24 @@
-fetch(
-    "https://tna.rosetta.k-int.com/rosetta/data/search?aggs=decade,year,century&filter=group:community",
-) // Replace with your server-side API endpoint
+const searchParams = new URLSearchParams(window.location.search);
+
+var url_string =
+    "https://tna.rosetta.k-int.com/rosetta/data/search?aggs=decade,year,century&filter=group%3Acommunity";
+
+var query = searchParams.get("q");
+
+if (query) {
+    url_string += "&q=" + query;
+}
+
+var collection = searchParams.get("collection");
+
+if (collection) {
+    url_string +=
+        "&filter=collectionOhos%3A" +
+        collection.substring(collection.indexOf(":") + 1).replace(/ /g, "+");
+}
+
+
+fetch(url_string) //  server-side API endpoint
     .then((response) => response.json())
     .then((data) => {
         const queryString = window.location.search;
@@ -106,11 +124,13 @@ fetch(
                 // console.log(clickedIndexAdjust);
                 // Access the corresponding record count from chart data
                 // const recordCount = chartData[clickedIndex];
+                var searchParams = new URLSearchParams(window.location.search);
+                searchParams.set("timeline_type", "year");
+                searchParams.set("startDate", clickedIndexAdjust);
 
                 const url =
-                    "./?vis_view=timeline&timeline_type=year&startDate=" +
-                    clickedIndexAdjust +
-                    "#myChart";
+                    "./?" + searchParams.toString() + "#myChart";
+                console.log(url);
                 window.location = url;
             }
         };

--- a/scripts/src/modules/timeline/century.js
+++ b/scripts/src/modules/timeline/century.js
@@ -124,7 +124,6 @@ fetch(url_string) //  server-side API endpoint
                 searchParams.set("startDate", targetDecade.decade);
 
                 const url = "./?" + searchParams.toString() + "#myChart";
-                console.log(url);
                 window.location = url;
             }
         };

--- a/scripts/src/modules/timeline/decade.js
+++ b/scripts/src/modules/timeline/decade.js
@@ -17,9 +17,7 @@ if (collection) {
         collection.substring(collection.indexOf(":") + 1).replace(/ /g, "+");
 }
 
-fetch(
-    url_string
-) // Replace with your server-side API endpoint
+fetch(url_string) // Replace with your server-side API endpoint
     .then((response) => response.json())
     .then((data) => {
         const queryString = window.location.search;

--- a/scripts/src/modules/timeline/decade.js
+++ b/scripts/src/modules/timeline/decade.js
@@ -1,5 +1,24 @@
+const searchParams = new URLSearchParams(window.location.search);
+
+var url_string =
+    "https://tna.rosetta.k-int.com/rosetta/data/search?aggs=century,community&filter=group%3Acommunity";
+
+var query = searchParams.get("q");
+
+if (query) {
+    url_string += "&q=" + query;
+}
+
+var collection = searchParams.get("collection");
+
+if (collection) {
+    url_string +=
+        "&filter=collectionOhos%3A" +
+        collection.substring(collection.indexOf(":") + 1).replace(/ /g, "+");
+}
+
 fetch(
-    "https://tna.rosetta.k-int.com/rosetta/data/search?aggs=decade,year,century&filter=group:community",
+    url_string
 ) // Replace with your server-side API endpoint
     .then((response) => response.json())
     .then((data) => {

--- a/scripts/src/modules/timeline/timeline.js
+++ b/scripts/src/modules/timeline/timeline.js
@@ -120,7 +120,6 @@ fetch(url_string) //  server-side API endpoint
                 searchParams.set("startDate", targetCentury.name);
 
                 const url = "./?" + searchParams.toString() + "#myChart";
-                console.log(url);
                 window.location = url;
             }
         };

--- a/scripts/src/modules/timeline/timeline.js
+++ b/scripts/src/modules/timeline/timeline.js
@@ -119,8 +119,7 @@ fetch(url_string) //  server-side API endpoint
                 searchParams.set("timeline_type", "decade");
                 searchParams.set("startDate", targetCentury.name);
 
-                const url =
-                    "./?" + searchParams.toString() + "#myChart";
+                const url = "./?" + searchParams.toString() + "#myChart";
                 console.log(url);
                 window.location = url;
             }

--- a/scripts/src/modules/timeline/timeline.js
+++ b/scripts/src/modules/timeline/timeline.js
@@ -113,14 +113,11 @@ fetch(url_string) //  server-side API endpoint
             );
             if (activePoints.length > 0) {
                 // Get the clicked bar index
-                const clickedIndex = activePoints[0].index * 100;
-                const clickedIndexAdjust = clickedIndex;
-                // clickedIndexAdjust = clickedIndex;
-                // Access the corresponding record count from chart data
-                // const recordCount = chartData[clickedIndex];
+                const targetCentury = centuries[activePoints[0].index];
+
                 var searchParams = new URLSearchParams(window.location.search);
                 searchParams.set("timeline_type", "decade");
-                searchParams.set("startDate", clickedIndexAdjust);
+                searchParams.set("startDate", targetCentury.name);
 
                 const url =
                     "./?" + searchParams.toString() + "#myChart";

--- a/scripts/src/modules/timeline/timeline.js
+++ b/scripts/src/modules/timeline/timeline.js
@@ -116,14 +116,15 @@ fetch(url_string) //  server-side API endpoint
                 const clickedIndex = activePoints[0].index * 100;
                 const clickedIndexAdjust = clickedIndex;
                 // clickedIndexAdjust = clickedIndex;
-                console.log(clickedIndexAdjust);
                 // Access the corresponding record count from chart data
                 // const recordCount = chartData[clickedIndex];
+                var searchParams = new URLSearchParams(window.location.search);
+                searchParams.set("timeline_type", "decade");
+                searchParams.set("startDate", clickedIndexAdjust);
 
                 const url =
-                    "./?vis_view=timeline&timeline_type=decade&startDate=" +
-                    clickedIndexAdjust +
-                    "#myChart";
+                    "./?" + searchParams.toString() + "#myChart";
+                console.log(url);
                 window.location = url;
             }
         };


### PR DESCRIPTION
Ticket URL: [HERITAGE-319]

## About these changes

Fixes the decade/year when clicking into the timeline, e.g. clicking 1900 would show 100 200 300, when it should be 1910, 1920, 1930

Now when it is clicked, it will show the expected result.

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [x] Ensured that PR includes only commits relevant to the ticket
- [x] Waited for all CI jobs to pass before requesting a review
- [x] Added/updated tests and documentation where relevant

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)


[HERITAGE-319]: https://national-archives.atlassian.net/browse/HERITAGE-319?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ