### PR TITLE
Make held by link point to discovery

### DIFF
--- a/etna/records/models.py
+++ b/etna/records/models.py
@@ -286,12 +286,9 @@ class Record(DataLayerMixin, APIModel):
     @cached_property
     def held_by_url(self) -> str:
         if self.held_by_id:
-            try:
-                return reverse(
-                    "details-page-machine-readable", kwargs={"id": self.held_by_id}
-                )
-            except NoReverseMatch:
-                pass
+            return (
+                f"https://discovery.nationalarchives.gov.uk/details/a/{self.held_by_id}"
+            )
         return ""
 
     @cached_property


### PR DESCRIPTION
Ticket URL: N/A

## About these changes

It was identified that accessing the “Held By” link results in an error due to incorrect data being returned. Additionally, there is currently no Archive Page configured for OHOS. To prevent the page from breaking, it was decided that the link should instead direct users to Archon page in Discovery.

## How to check these changes

- http://127.0.0.1:8002/catalogue/id/C17320061/ 
- http://127.0.0.1:8002/catalogue/id/c417b85f-6d2d-4605-9c06-dc728676c91f/
when Held By link in clicked, it should go to corresponding Archon page in Discovery

## Before assigning to reviewer, please make sure you have

- [ ] Checked things thoroughly before handing over to reviewer
- [ ] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [ ] Ensured that PR includes only commits relevant to the ticket
- [ ] Waited for all CI jobs to pass before requesting a review
- [ ] Added/updated tests and documentation where relevant

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
